### PR TITLE
Ensure consistent LoRaFlexSim naming

### DIFF
--- a/loraflexsim/run.py
+++ b/loraflexsim/run.py
@@ -44,7 +44,7 @@ def simulate(
     rng_manager: RngManager | None = None,
     non_orth_delta: list[list[float]] | None = None,
 ):
-    """Exécute une simulation LoRa simplifiée et retourne les métriques.
+    """Exécute une simulation LoRaFlexSim simplifiée et retourne les métriques.
 
     Les transmissions peuvent se faire sur plusieurs canaux et plusieurs
     passerelles. Les nœuds sont répartis de façon uniforme sur les ``channels``


### PR DESCRIPTION
## Summary
- Reference **LoRaFlexSim** directly in `simulate` docstring of CLI runner

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adbbb536a0833189fb64e25bf45520