### PR TITLE
docs: clarify LoRaFlexSim references in validation docs

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -20,4 +20,4 @@ Expected output:
 136 passed, 13 skipped in 33.47s
 ```
 
-In the current environment Docker is unavailable, so the image could not be built. Running `pytest -q` directly produced the above results.
+In the current environment Docker is unavailable, so the LoRaFlexSim image could not be built. Running `pytest -q` directly produced the above results.

--- a/VALIDATION_TRAFFIC_EXP.md
+++ b/VALIDATION_TRAFFIC_EXP.md
@@ -1,7 +1,7 @@
 # Validation Traffic Exponentiel
 
 Ce document rassemble les valeurs obtenues en testant la fonction
-`traffic.exponential.sample_interval`.
+`traffic.exponential.sample_interval` du simulateur LoRaFlexSim.
 
 Paramètres utilisés :
 - `mean_interval` = 10 secondes


### PR DESCRIPTION
## Summary
- mention LoRaFlexSim in exponential traffic validation note
- clarify Docker image reference in validation overview

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adbbaf021c833196035a573698c832