### PR TITLE
docs: highlight LoRaFlexSim 1.0.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LoRaFlexSim : simulateur réseau LoRa (Python 3.10+)
+# LoRaFlexSim 1.0.0 : simulateur réseau LoRa (Python 3.10+)
 
 Bienvenue ! **LoRaFlexSim** est un **simulateur complet de réseau LoRa**, inspiré du fonctionnement de FLoRa sous OMNeT++, codé entièrement en Python.
 Pour un aperçu des différences avec FLoRa, consultez docs/lorawan_features.md.


### PR DESCRIPTION
## Summary
- mention LoRaFlexSim 1.0.0 in the README title

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae28cee7808331a084b7543d99e4ff