### PR TITLE
Add 1.0.0 release notes to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - LoRaWAN implementation with ADR logic, classes B and C, and AES-128 security.
 - CSV export and detailed metrics.
 - Unit tests with pytest and analysis scripts.
+
+## [1.0.0] - 2025-08-26
+### Added
+- Initial public release of LoRaFlexSim, offering a flexible LoRa network simulator.
+- Command-line interface with example scenarios.
+- Documentation and basic unit tests.


### PR DESCRIPTION
## Summary
- document initial LoRaFlexSim release in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae28d351c483318881a3c44e13fb5e