### PR TITLE
Clarify simulator name in launcher comments

### DIFF
--- a/loraflexsim/launcher/adr_standard_1.py
+++ b/loraflexsim/launcher/adr_standard_1.py
@@ -109,7 +109,7 @@ def apply(
     sim.network_server.adr_method = "avg"
     for node in sim.nodes:
         # Démarre au SF12 pour une sensibilité maximale sauf si un SF fixe est
-        # déjà défini par le simulateur
+        # déjà défini par le simulateur LoRaFlexSim
         if getattr(sim, "fixed_sf", None) is None:
             node.sf = 12
             node.initial_sf = 12

--- a/loraflexsim/launcher/node.py
+++ b/loraflexsim/launcher/node.py
@@ -97,7 +97,7 @@ class Node:
         self.sf = sf
         self.initial_tx_power = tx_power
         self.tx_power = tx_power
-        # Canal radio attribué (peut être modifié par le simulateur)
+        # Canal radio attribué (peut être modifié par le simulateur LoRaFlexSim)
         # Utiliser un canal par défaut si aucun n'est fourni pour éviter
         # des erreurs lors des calculs d'airtime ou de RSSI.
         self.channel = channel or Channel()


### PR DESCRIPTION
## Summary
- explicitly reference the LoRaFlexSim simulator in ADR setup comments
- clarify that radio channel may be modified by the LoRaFlexSim simulator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae28f3fd20833199a8112f59861ca1