### PR TITLE
Export figures in multiple formats

### DIFF
--- a/scripts/plot_battery_tracking.py
+++ b/scripts/plot_battery_tracking.py
@@ -95,9 +95,12 @@ def main() -> None:
     ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
 
     os.makedirs(FIGURES_DIR, exist_ok=True)
-    out_path = os.path.join(FIGURES_DIR, "battery_tracking.png")
-    fig.savefig(out_path)
-    print(f"Saved {out_path}")
+    base = os.path.join(FIGURES_DIR, "battery_tracking")
+    for ext in ("png", "jpg", "eps"):
+        dpi = 300 if ext in ("png", "jpg") else None
+        path = f"{base}.{ext}"
+        fig.savefig(path, dpi=dpi)
+        print(f"Saved {path}")
 
 
 if __name__ == "__main__":  # pragma: no cover - script entry point

--- a/scripts/plot_channels_sweep.py
+++ b/scripts/plot_channels_sweep.py
@@ -51,9 +51,12 @@ def main() -> None:
 
     fig.tight_layout()
     os.makedirs(FIGURES_DIR, exist_ok=True)
-    out_path = os.path.join(FIGURES_DIR, "pdr_collisions_vs_channels.png")
-    fig.savefig(out_path)
-    print(f"Saved {out_path}")
+    base = os.path.join(FIGURES_DIR, "pdr_collisions_vs_channels")
+    for ext in ("png", "jpg", "eps"):
+        dpi = 300 if ext in ("png", "jpg") else None
+        path = f"{base}.{ext}"
+        fig.savefig(path, dpi=dpi)
+        print(f"Saved {path}")
 
 
 if __name__ == "__main__":  # pragma: no cover - script entry point

--- a/scripts/plot_interval_sweep.py
+++ b/scripts/plot_interval_sweep.py
@@ -41,9 +41,12 @@ def main() -> None:
     axes[1].set_title("Collisions vs Interval")
 
     fig.tight_layout()
-    out_path = FIGURES_DIR / "pdr_collisions_vs_interval.png"
-    fig.savefig(out_path)
-    print(f"Saved {out_path}")
+    base = FIGURES_DIR / "pdr_collisions_vs_interval"
+    for ext in ("png", "jpg", "eps"):
+        dpi = 300 if ext in ("png", "jpg") else None
+        path = base.with_suffix(f".{ext}")
+        fig.savefig(path, dpi=dpi)
+        print(f"Saved {path}")
 
 
 if __name__ == "__main__":  # pragma: no cover - script entry point

--- a/scripts/plot_mobility_latency_energy.py
+++ b/scripts/plot_mobility_latency_energy.py
@@ -109,7 +109,10 @@ def plot(
         ax.bar_label(bars, fmt=fmt, label_type="center")
         ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
         fig.tight_layout(rect=[0, 0.2, 0.9, 1])
-        fig.savefig(out_dir / filename)
+        stem = Path(filename).stem
+        for ext in ("png", "jpg", "eps"):
+            dpi = 300 if ext in ("png", "jpg") else None
+            fig.savefig(out_dir / f"{stem}.{ext}", dpi=dpi)
         plt.close(fig)
 
 

--- a/scripts/plot_mobility_models.py
+++ b/scripts/plot_mobility_models.py
@@ -72,7 +72,9 @@ def plot(
         ax.bar_label(bars, fmt=fmt, label_type="center")
         ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
         fig.tight_layout(rect=[0, 0.2, 0.9, 1])
-        fig.savefig(out_dir / f"{metric}_vs_model.png")
+        for ext in ("png", "jpg", "eps"):
+            dpi = 300 if ext in ("png", "jpg") else None
+            fig.savefig(out_dir / f"{metric}_vs_model.{ext}", dpi=dpi)
         plt.close(fig)
 
 

--- a/scripts/plot_mobility_multichannel.py
+++ b/scripts/plot_mobility_multichannel.py
@@ -90,8 +90,10 @@ def plot(
         ax.set_title(title)
         ax.bar_label(bars, fmt=fmt, label_type="center")
         ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
-        fig.tight_layout(rect=[0, 0.2, 0.9, 1])
-        fig.savefig(out_dir / f"{metric}_vs_scenario.png")
+       fig.tight_layout(rect=[0, 0.2, 0.9, 1])
+        for ext in ("png", "jpg", "eps"):
+            dpi = 300 if ext in ("png", "jpg") else None
+            fig.savefig(out_dir / f"{metric}_vs_scenario.{ext}", dpi=dpi)
         plt.close(fig)
 
 

--- a/scripts/plot_node_positions.py
+++ b/scripts/plot_node_positions.py
@@ -86,7 +86,9 @@ def main(argv: list[str] | None = None) -> None:
     ax.set_xlabel("x")
     ax.set_ylabel("y")
     ax.set_title("Node positions")
-    fig.savefig(output_path)
+    for ext in (".png", ".jpg", ".eps"):
+        dpi = 300 if ext in (".png", ".jpg") else None
+        fig.savefig(output_path.with_suffix(ext), dpi=dpi)
     plt.close(fig)
 
 

--- a/scripts/plot_noise_sweep.py
+++ b/scripts/plot_noise_sweep.py
@@ -36,10 +36,13 @@ def main() -> None:
     ax.set_xlabel("noise_std")
     ax.set_ylabel("PDR(%)")
     ax.set_title("PDR vs Noise")
-    output_path = FIGURES_DIR / "pdr_vs_noise.png"
-    fig.savefig(output_path)
+    output_base = FIGURES_DIR / "pdr_vs_noise"
+    for ext in ("png", "jpg", "eps"):
+        dpi = 300 if ext in ("png", "jpg") else None
+        path = output_base.with_suffix(f".{ext}")
+        fig.savefig(path, dpi=dpi)
+        print(f"Saved {path}")
     plt.close(fig)
-    print(f"Saved {output_path}")
 
 
 if __name__ == "__main__":

--- a/scripts/plot_sf_vs_scenario.py
+++ b/scripts/plot_sf_vs_scenario.py
@@ -52,8 +52,10 @@ def plot(csv_path: str, output_dir: str = "figures", by_model: bool = False) -> 
     ax.bar_label(bars, fmt="%.2f", label_type="center")
     fig.tight_layout()
 
-    filename = "avg_sf_vs_model.png" if by_model else "avg_sf_vs_scenario.png"
-    fig.savefig(out_dir / filename)
+    stem = "avg_sf_vs_model" if by_model else "avg_sf_vs_scenario"
+    for ext in ("png", "jpg", "eps"):
+        dpi = 300 if ext in ("png", "jpg") else None
+        fig.savefig(out_dir / f"{stem}.{ext}", dpi=dpi)
     plt.close(fig)
 
 

--- a/tests/test_battery_tracking_script.py
+++ b/tests/test_battery_tracking_script.py
@@ -46,10 +46,10 @@ def test_battery_tracking_script(tmp_path, monkeypatch):
     monkeypatch.setattr(plot_battery_tracking, "RESULTS_DIR", tmp_path)
     monkeypatch.setattr(plot_battery_tracking, "FIGURES_DIR", figures_dir)
     plot_battery_tracking.main()
-    png_path = figures_dir / "battery_tracking.png"
-    assert png_path.is_file()
-
-    png_path.unlink()
+    for ext in ("png", "jpg", "eps"):
+        path = figures_dir / f"battery_tracking.{ext}"
+        assert path.is_file()
+        path.unlink()
     figures_dir.rmdir()
     csv_path.unlink()
 


### PR DESCRIPTION
## Summary
- save plots as PNG, JPG, and EPS, using 300 DPI for bitmap formats
- update battery-tracking test to handle the additional output files

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc5fbdaa608331bf169576c065190a