### PR TITLE
Use scenario labels on plot x-axes

### DIFF
--- a/scripts/plot_mobility_latency_energy.py
+++ b/scripts/plot_mobility_latency_energy.py
@@ -73,10 +73,13 @@ def plot(
         if mean_col not in df.columns:
             continue
         yerr = df[std_col] if std_col in df.columns else None
-        fig, ax = plt.subplots(figsize=(12, 6))
+        labels = df["scenario_label"]
+        width = max(12, 0.5 * len(labels))
+        fig, ax = plt.subplots(figsize=(width, 6))
         label = f"{name} ({unit})"
+        x = range(len(labels))
         bars = ax.bar(
-            df["scenario"],
+            x,
             df[mean_col],
             yerr=yerr,
             capsize=4,
@@ -84,8 +87,8 @@ def plot(
             label=label,
         )
         ax.set_xlabel("Scenario")
-        ax.set_xticks(range(len(df["scenario"])))
-        ax.set_xticklabels(df["scenario"], rotation=45, ha="right")
+        ax.set_xticks(x)
+        ax.set_xticklabels(labels, rotation=45, ha="right")
         ax.set_ylabel(label)
 
         if metric == "pdr":

--- a/scripts/plot_mobility_multichannel.py
+++ b/scripts/plot_mobility_multichannel.py
@@ -55,10 +55,13 @@ def plot(
         if mean_col not in df.columns:
             continue
         yerr = df[std_col] if std_col in df.columns else None
-        fig, ax = plt.subplots(figsize=(12, 6))
+        labels = df["scenario_label"]
+        width = max(12, 0.5 * len(labels))
+        fig, ax = plt.subplots(figsize=(width, 6))
         label = f"{name} ({unit})"
+        x = range(len(labels))
         bars = ax.bar(
-            df["scenario"],
+            x,
             df[mean_col],
             yerr=yerr,
             capsize=4,
@@ -66,8 +69,8 @@ def plot(
             label=label,
         )
         ax.set_xlabel("Scenario")
-        ax.set_xticks(range(len(df["scenario"])))
-        ax.set_xticklabels(df["scenario"], rotation=45, ha="right")
+        ax.set_xticks(x)
+        ax.set_xticklabels(labels, rotation=45, ha="right")
         ax.set_ylabel(label)
 
         if metric == "pdr":

--- a/scripts/plot_sf_vs_scenario.py
+++ b/scripts/plot_sf_vs_scenario.py
@@ -32,8 +32,11 @@ def plot(csv_path: str, output_dir: str = "figures", by_model: bool = False) -> 
     """
     df = pd.read_csv(csv_path)
 
-    x_col = "model" if by_model else "scenario"
-    required = {x_col, "avg_sf_mean", "avg_sf_std"}
+    required = (
+        {"model", "avg_sf_mean", "avg_sf_std"}
+        if by_model
+        else {"scenario_label", "avg_sf_mean", "avg_sf_std"}
+    )
     if not required <= set(df.columns):
         missing = ", ".join(sorted(required - set(df.columns)))
         raise SystemExit(f"CSV must contain columns: {missing}")
@@ -41,11 +44,13 @@ def plot(csv_path: str, output_dir: str = "figures", by_model: bool = False) -> 
     out_dir = Path(output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    fig, ax = plt.subplots(figsize=(12, 6))
-    x = range(len(df[x_col]))
+    labels = df["model"] if by_model else df["scenario_label"]
+    width = max(12, 0.5 * len(labels))
+    fig, ax = plt.subplots(figsize=(width, 6))
+    x = range(len(labels))
     bars = ax.bar(x, df["avg_sf_mean"], yerr=df["avg_sf_std"], capsize=4, color="C0")
     ax.set_xticks(x)
-    ax.set_xticklabels(df[x_col], rotation=45, ha="right")
+    ax.set_xticklabels(labels, rotation=45, ha="right")
     ax.set_xlabel("Mobility model" if by_model else "Scenario")
     ax.set_ylabel("Average SF")
     ax.set_title("Average SF by " + ("model" if by_model else "scenario"))


### PR DESCRIPTION
## Summary
- Rotate and right-align x-axis labels using new `scenario_label` column for scenario plots
- Expand figure width based on number of scenarios for clearer labels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc5fc1100883319cf9bf33d55693b8