### PR TITLE
Correct area labeling for mobility plots

### DIFF
--- a/scripts/plot_mobility_latency_energy.py
+++ b/scripts/plot_mobility_latency_energy.py
@@ -34,7 +34,7 @@ def plot(
     if "speed" in df.columns:
         params.append(f"speed={df['speed'].iloc[0]:g}m/s")
     if "area_size" in df.columns:
-        params.append(f"area={df['area_size'].iloc[0]:g}m²")
+        params.append(f"area={df['area_size'].iloc[0] ** 2:g}m²")
     if "channels" in df.columns:
         params.append(f"channels={int(df['channels'].iloc[0])}")
     param_text = ", ".join(params)

--- a/scripts/plot_mobility_multichannel.py
+++ b/scripts/plot_mobility_multichannel.py
@@ -35,10 +35,12 @@ def plot(
         + ", C="
         + df["channels"].astype(int).astype(str)
     )
+    if "area_size" in df.columns:
+        df["area"] = df["area_size"] ** 2
     optional_params = [
         ("interval", "interval={:g}s"),
         ("speed", "speed={:g}m/s"),
-        ("area_size", "area={:g}m²"),
+        ("area", "area={:g}m²"),
     ]
     for col, fmt in optional_params:
         if col in df.columns and df[col].nunique() > 1:


### PR DESCRIPTION
## Summary
- compute area from side length for scenario labels in multichannel plots
- propagate accurate area info to mobility latency/energy plots

## Testing
- `pytest tests/test_mobility_multichannel_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcab0a2bfc833184af2dcd902fa85d