### PR TITLE
Scale multichannel mobility plot width with scenarios

### DIFF
--- a/scripts/plot_mobility_multichannel.py
+++ b/scripts/plot_mobility_multichannel.py
@@ -59,7 +59,8 @@ def plot(
         if mean_col not in df.columns:
             continue
         yerr = df[std_col] if std_col in df.columns else None
-        fig, ax = plt.subplots(figsize=(12, 6))
+        fig_width = max(12, 0.6 * len(df))
+        fig, ax = plt.subplots(figsize=(fig_width, 6))
         label = f"{name} ({unit})"
         bars = ax.bar(
             range(len(df)),


### PR DESCRIPTION
## Summary
- Scale mobility multichannel plot width proportionally to the number of scenarios for improved readability

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcaca73d3083319b0d203a2bc1a64f