### PR TITLE
Fix indentation in multichannel plot script

### DIFF
--- a/scripts/plot_mobility_multichannel.py
+++ b/scripts/plot_mobility_multichannel.py
@@ -92,7 +92,7 @@ def plot(
         ax.set_title(title)
         ax.bar_label(bars, fmt=fmt, label_type="center")
         ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
-       fig.tight_layout(rect=[0, 0.2, 0.9, 1])
+        fig.tight_layout(rect=[0, 0.2, 0.9, 1])
         for ext in ("png", "jpg", "eps"):
             dpi = 300 if ext in ("png", "jpg") else None
             fig.savefig(out_dir / f"{metric}_vs_scenario.{ext}", dpi=dpi)


### PR DESCRIPTION
## Summary
- align fig.tight_layout call with other operations in plotting loop

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcacaa32d083318b06067ae0d5bd35