### PR TITLE
test: add stub metrics and cleanup fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import random
 import os
 import sys
+import shutil
 import pytest
 
 # Ensure the project root is on the module search path when the package is not
@@ -18,10 +19,24 @@ if STUBS_DIR not in sys.path:
     sys.path.insert(0, STUBS_DIR)
 
 import numpy_stub
+import scipy
 
 sys.modules.setdefault("numpy", numpy_stub)
 sys.modules.setdefault("numpy.random", numpy_stub.random)
+sys.modules.setdefault("scipy", scipy)
+sys.modules.setdefault("scipy.stats", scipy.stats)
 
 @pytest.fixture(autouse=True)
 def _set_seed():
     random.seed(1)
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_tmp_path(tmp_path):
+    """Remove temporary files created during tests."""
+    yield
+    for path in tmp_path.iterdir():
+        if path.is_dir():
+            shutil.rmtree(path, ignore_errors=True)
+        else:
+            path.unlink()

--- a/tests/test_stub_metrics.py
+++ b/tests/test_stub_metrics.py
@@ -1,0 +1,43 @@
+"""Tests ensuring simulations rely on stubbed dependencies and cleanup."""
+
+from pathlib import Path
+
+import numpy as np
+import scipy
+
+from loraflexsim.launcher.simulator import Simulator
+
+
+TMP_FILENAME = "temp_file_cleanup_test.txt"
+
+
+def test_simulation_uses_stubbed_metrics() -> None:
+    """Simulator should run using stub versions of numpy and scipy."""
+    assert np.__name__ == "numpy_stub"
+    assert "scipy/stats.py" in Path(scipy.stats.__file__).as_posix()
+
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        transmission_mode="Random",
+        packet_interval=1.0,
+        packets_to_send=1,
+        duty_cycle=0.01,
+        seed=0,
+    )
+    sim.run()
+    metrics = sim.get_metrics()
+    assert "PDR" in metrics
+
+
+def test_tmp_path_cleanup(tmp_path) -> None:
+    """Temporary files are removed after each test."""
+    tmp_file = tmp_path / TMP_FILENAME
+    tmp_file.write_text("data")
+    assert tmp_file.exists()
+
+
+def test_no_tmp_artifacts(tmp_path_factory) -> None:
+    base = tmp_path_factory.getbasetemp()
+    assert not list(base.glob(f"**/{TMP_FILENAME}"))
+


### PR DESCRIPTION
## Summary
- ensure numpy and scipy are stubbed in tests
- clean tmp_path contents after each test
- add tests verifying stubbed metrics and temp file cleanup

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcacd798c483319234f62076595405