### PR TITLE
Use explicit exception types instead of assertions

### DIFF
--- a/loraflexsim/launcher/node.py
+++ b/loraflexsim/launcher/node.py
@@ -522,18 +522,17 @@ class Node:
         """
         if rng is None:
             rng = self.rng
-        assert isinstance(rng, np.random.Generator) and isinstance(
-            rng.bit_generator, np.random.MT19937
-        ), "rng must be numpy.random.Generator using MT19937"
-        assert isinstance(mean_interval, float) and mean_interval > 0, (
-            "mean_interval must be positive float"
-        )
-        assert isinstance(min_interval, float) and min_interval >= 0.0, (
-            "min_interval must be non-negative float"
-        )
-        assert isinstance(variation, float) and variation >= 0.0, (
-            "variation must be non-negative float"
-        )
+        if not (
+            isinstance(rng, np.random.Generator)
+            and isinstance(rng.bit_generator, np.random.MT19937)
+        ):
+            raise TypeError("rng must be numpy.random.Generator using MT19937")
+        if not (isinstance(mean_interval, float) and mean_interval > 0):
+            raise ValueError("mean_interval must be positive float")
+        if not (isinstance(min_interval, float) and min_interval >= 0.0):
+            raise ValueError("min_interval must be non-negative float")
+        if not (isinstance(variation, float) and variation >= 0.0):
+            raise ValueError("variation must be non-negative float")
         last = self.arrival_queue[-1] if self.arrival_queue else self._last_arrival_time
         while (not self.arrival_queue or last <= up_to) and (
             limit is None or self.arrival_interval_count < limit

--- a/tests/test_exp_asserts.py
+++ b/tests/test_exp_asserts.py
@@ -6,7 +6,7 @@ from traffic.exponential import sample_exp
 
 def test_sample_exp_asserts():
     rng = np.random.Generator(np.random.MT19937(0))
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         sample_exp(-1.0, rng)
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         sample_exp(10, rng)  # not float

--- a/tests/test_interval_asserts.py
+++ b/tests/test_interval_asserts.py
@@ -7,18 +7,18 @@ from loraflexsim.launcher.node import Node
 
 def test_sample_interval_asserts():
     rng = np.random.Generator(np.random.MT19937(0))
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         sample_interval(-1.0, rng)
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         sample_interval(10, rng)  # not float
 
 
 def test_node_poisson_assert():
     rng = np.random.Generator(np.random.MT19937(0))
     node = Node(0, 0, 0, 7, 20)
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         node.ensure_poisson_arrivals(10.0, -5.0, rng)
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         node.ensure_poisson_arrivals(10.0, 5, rng)
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         node.ensure_poisson_arrivals(10.0, 5.0, rng, variation=-1.0)

--- a/traffic/exponential.py
+++ b/traffic/exponential.py
@@ -11,7 +11,7 @@ def sample_interval(mean: float, rng: np.random.Generator) -> float:
     """Return a delay drawn from an exponential distribution.
 
     ``mean`` is expressed in seconds and must be a positive float. Any
-    other type or non-positive value triggers an :class:`AssertionError`.
+    other type or non-positive value triggers a :class:`ValueError`.
 
     The value is generated using inverse transform sampling with a
     ``numpy.random.Generator`` based on ``MT19937`` to match the algorithm
@@ -25,12 +25,15 @@ def sample_interval(mean: float, rng: np.random.Generator) -> float:
     # ``numpy`` exposes its own floating types which are not instances of
     # :class:`float`.  Hidden tests may provide such a value, so accept any
     # real number while explicitly rejecting integral types (including ``bool``)
-    # to preserve the public API which raises for integers.
-    assert (
+    # to preserve the public API which raises for integers.  ``assert`` should
+    # not be used for runtime validation as it may be optimized out, so raise a
+    # ``ValueError`` instead.
+    if not (
         isinstance(mean, numbers.Real)
         and not isinstance(mean, numbers.Integral)
         and mean > 0
-    ), "mean_interval must be positive float"
+    ):
+        raise ValueError("mean_interval must be positive float")
     mean = float(mean)
     u = rng.random()
     return -mean * math.log(1.0 - u)
@@ -42,18 +45,19 @@ def sample_exp(mu_send: float, rng: np.random.Generator) -> float:
     ``mu_send`` corresponds to the expected value of the distribution and
     must be provided as a positive float. ``rng`` must be a
     :class:`numpy.random.Generator` instance using the ``MT19937`` bit
-    generator. Any other types or non-positive value result in an
-    :class:`AssertionError`.
+    generator. Any other types or non-positive value result in a
+    :class:`ValueError`.
     """
     if not isinstance(rng, np.random.Generator) or not isinstance(
         rng.bit_generator, np.random.MT19937
     ):
         raise TypeError("rng must be numpy.random.Generator using MT19937")
-    assert (
+    if not (
         isinstance(mu_send, numbers.Real)
         and not isinstance(mu_send, numbers.Integral)
         and mu_send > 0
-    ), "mu_send must be positive float"
+    ):
+        raise ValueError("mu_send must be positive float")
     mu_send = float(mu_send)
     lam = 1.0 / mu_send
     u = rng.random()


### PR DESCRIPTION
## Summary
- replace asserts with runtime checks raising ValueError or TypeError in sampling utilities and Poisson arrival scheduling
- update tests to expect ValueError instead of AssertionError
- document that non-positive parameters now raise ValueError

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf3501623083319da5aa8b2c16aee4