### PR TITLE
Avoid duplicate gateways in NetworkServer wrapper

### DIFF
--- a/loraflexsim/architecture.py
+++ b/loraflexsim/architecture.py
@@ -67,7 +67,17 @@ class NetworkServer(_NetworkServer):
     """Serveur réseau LoRa."""
 
     def add_gateway(self, gw: _Gateway) -> None:
-        self.gateways.append(gw)
+        """Register ``gw`` if not already present.
+
+        The lightweight wrapper originally added gateways blindly which could
+        result in duplicates when ``add_gateway`` was called multiple times with
+        the same instance.  The internal :attr:`gateways` list is now checked to
+        ensure each gateway is stored only once, mirroring the behaviour of
+        :meth:`register_node` for nodes.
+        """
+
+        if gw not in self.gateways:
+            self.gateways.append(gw)
 
     def register_node(self, node: _Node) -> None:
         if node not in self.nodes:

--- a/tests/test_network_server.py
+++ b/tests/test_network_server.py
@@ -1,6 +1,8 @@
 from loraflexsim.launcher.server import NetworkServer
 from loraflexsim.launcher.gateway import Gateway
 from loraflexsim.launcher.node import Node
+from loraflexsim.architecture import NetworkServer as SimpleServer
+
 
 
 def test_deduplicate_packets():
@@ -17,3 +19,11 @@ def test_deduplicate_packets():
     assert server.packets_received == 1
     assert server.duplicate_packets == 1
     assert server.event_gateway[1] == gw1.id
+
+
+def test_add_gateway_deduplicates():
+    server = SimpleServer()
+    gw = Gateway(0, 0, 0)
+    server.add_gateway(gw)
+    server.add_gateway(gw)
+    assert server.gateways == [gw]


### PR DESCRIPTION
## Summary
- prevent `NetworkServer.add_gateway` from inserting the same gateway multiple times
- add regression test for gateway deduplication

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf3572f190833183b505921945a386