### PR TITLE
Add EXPLoRa-SF ADR algorithm and dashboard integration

### DIFF
--- a/loraflexsim/launcher/__init__.py
+++ b/loraflexsim/launcher/__init__.py
@@ -22,7 +22,7 @@ from .omnet_model import OmnetModel
 from .omnet_phy import OmnetPHY
 from .flora_cpp import FloraCppPHY
 from .obstacle_loss import ObstacleLoss
-from . import adr_standard_1, adr_2, adr_3
+from . import adr_standard_1, adr_2, adr_3, explora_sf
 
 __all__ = [
     "Node",
@@ -54,6 +54,7 @@ __all__ = [
     "adr_standard_1",
     "adr_2",
     "adr_3",
+    "explora_sf",
 ]
 
 for name in __all__:

--- a/loraflexsim/launcher/dashboard.py
+++ b/loraflexsim/launcher/dashboard.py
@@ -24,14 +24,15 @@ for path in (ROOT_DIR, REPO_ROOT):
 
 from launcher.simulator import Simulator  # noqa: E402
 from launcher.channel import Channel  # noqa: E402
-from launcher import adr_standard_1, adr_2, adr_3  # noqa: E402
+from launcher import adr_standard_1, adr_2, adr_3, explora_sf  # noqa: E402
 
 # --- Initialisation Panel ---
 pn.extension("plotly", raw_css=[
     ".coord-textarea textarea {font-size: 14pt;}",
 ])
 # Définition du titre de la page via le document Bokeh directement
-pn.state.curdoc.title = "Simulateur LoRa"
+if pn.state.curdoc:
+    pn.state.curdoc.title = "Simulateur LoRa"
 
 # --- Variables globales ---
 sim = None
@@ -132,6 +133,7 @@ adr_server_checkbox = pn.widgets.Checkbox(name="ADR serveur", value=True)
 adr1_button = pn.widgets.Button(name="adr_1", button_type="primary")
 adr2_button = pn.widgets.Button(name="adr_2")
 adr3_button = pn.widgets.Button(name="adr_3")
+explora_sf_button = pn.widgets.Button(name="EXPLoRa-SF")
 adr_active_badge = pn.pane.HTML("", width=80)
 
 # --- Choix SF et puissance initiaux identiques ---
@@ -536,14 +538,16 @@ def select_adr(module, name: str) -> None:
     adr_node_checkbox.value = True
     adr_server_checkbox.value = True
     _update_adr_badge(name)
-    for btn in (adr1_button, adr2_button, adr3_button):
+    for btn in (adr1_button, adr2_button, adr3_button, explora_sf_button):
         btn.button_type = "default"
     if name == "ADR 1":
         adr1_button.button_type = "primary"
     elif name == "ADR 2":
         adr2_button.button_type = "primary"
-    else:
+    elif name == "ADR 3":
         adr3_button.button_type = "primary"
+    else:
+        explora_sf_button.button_type = "primary"
     if sim is not None:
         if module is adr_standard_1:
             module.apply(sim, degrade_channel=True, profile="flora")
@@ -1227,6 +1231,7 @@ show_paths_checkbox.param.watch(lambda event: update_map(), "value")
 adr1_button.on_click(lambda event: select_adr(adr_standard_1, "ADR 1"))
 adr2_button.on_click(lambda event: select_adr(adr_2, "ADR 2"))
 adr3_button.on_click(lambda event: select_adr(adr_3, "ADR 3"))
+explora_sf_button.on_click(lambda event: select_adr(explora_sf, "EXPLoRa-SF"))
 
 # --- Associer les callbacks aux boutons ---
 start_button.on_click(on_start)
@@ -1246,7 +1251,7 @@ controls = pn.WidgetBox(
     num_runs_input,
     adr_node_checkbox,
     adr_server_checkbox,
-    pn.Row(adr1_button, adr2_button, adr3_button, adr_active_badge),
+    pn.Row(adr1_button, adr2_button, adr3_button, explora_sf_button, adr_active_badge),
     fixed_sf_checkbox,
     sf_value_input,
     fixed_power_checkbox,

--- a/loraflexsim/launcher/explora_sf.py
+++ b/loraflexsim/launcher/explora_sf.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from .simulator import Simulator
+from .channel import Channel
+
+
+def apply(sim: Simulator) -> None:
+    """Configure the EXPLoRa-SF ADR algorithm.
+
+    This enables both node and server side ADR and initialises all nodes
+    with parameters suitable for the EXPLoRa-SF strategy.  Each node starts
+    with a conservative spreading factor and default transmit power so that
+    the network server can quickly optimise the value based on the measured
+    SNR of the first uplinks.
+    """
+    # Typical installation margin for EXPLoRa-SF.  Both the simulator and
+    # the network server rely on this constant when evaluating SNR margins.
+    Simulator.MARGIN_DB = 15.0
+    from . import server as ns
+
+    ns.MARGIN_DB = 15.0
+
+    sim.adr_node = True
+    sim.adr_server = True
+    sim.network_server.adr_enabled = True
+    sim.network_server.adr_method = "explora-sf"
+
+    for node in sim.nodes:
+        # Start with the most robust SF so that connectivity is guaranteed
+        # before the server sends an optimised value based on the first
+        # measurements.
+        node.sf = 12
+        node.initial_sf = 12
+        node.channel.detection_threshold_dBm = (
+            Channel.flora_detection_threshold(node.sf, node.channel.bandwidth)
+            + node.channel.sensitivity_margin_dB
+        )
+        node.tx_power = 14.0
+        node.initial_tx_power = 14.0
+        node.adr_ack_cnt = 0
+        node.adr_ack_limit = 64
+        node.adr_ack_delay = 32
+
+    for ch in sim.multichannel.channels:
+        ch.detection_threshold_dBm = (
+            Channel.flora_detection_threshold(12, ch.bandwidth)
+            + ch.sensitivity_margin_dB
+        )

--- a/loraflexsim/launcher/tests/test_explora_sf.py
+++ b/loraflexsim/launcher/tests/test_explora_sf.py
@@ -1,0 +1,35 @@
+import random
+from loraflexsim.launcher.simulator import Simulator
+from loraflexsim.launcher import explora_sf
+from loraflexsim.launcher.server import REQUIRED_SNR, MARGIN_DB
+
+
+def test_explora_sf_assigns_optimal_sf():
+    random.seed(0)
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        transmission_mode="Periodic",
+        packet_interval=1.0,
+        duty_cycle=None,
+        mobility=False,
+        adr_node=False,
+        adr_server=False,
+        seed=42,
+    )
+    explora_sf.apply(sim)
+    node = sim.nodes[0]
+    gw = sim.gateways[0]
+    rssi = -40
+    frame = node.prepare_uplink(b"ping")
+    sim.network_server.receive(0, node.id, gw.id, rssi, frame)
+    dl = gw.pop_downlink(node.id)
+    assert dl is not None
+    node.handle_downlink(dl)
+    snr = rssi - node.channel.noise_floor_dBm()
+    expected_sf = 12
+    for sf in range(7, 13):
+        if snr >= REQUIRED_SNR.get(sf, -20.0) + MARGIN_DB:
+            expected_sf = sf
+            break
+    assert node.sf == expected_sf


### PR DESCRIPTION
## Summary
- implement EXPLoRa-SF ADR profile enabling node/server ADR and default parameters
- extend network server to compute SNR-based optimal SF and push via LinkADRReq
- expose algorithm in package and dashboard with dedicated button
- add unit test for EXPLoRa-SF

## Testing
- `PYTHONPATH=. pytest loraflexsim/launcher/tests/test_explora_sf.py -q`
- `PYTHONPATH=. pytest loraflexsim/launcher/tests -q` *(fails: test_obstacle_loss_reduces_rssi)*

------
https://chatgpt.com/codex/tasks/task_e_68c172ba76fc8331a59bbf389fe471f6