### PR TITLE
Add ADR max profile and integrate into dashboard

### DIFF
--- a/loraflexsim/launcher/__init__.py
+++ b/loraflexsim/launcher/__init__.py
@@ -22,7 +22,7 @@ from .omnet_model import OmnetModel
 from .omnet_phy import OmnetPHY
 from .flora_cpp import FloraCppPHY
 from .obstacle_loss import ObstacleLoss
-from . import adr_standard_1, adr_2, adr_3
+from . import adr_standard_1, adr_2, adr_3, adr_max
 
 __all__ = [
     "Node",
@@ -54,6 +54,7 @@ __all__ = [
     "adr_standard_1",
     "adr_2",
     "adr_3",
+    "adr_max",
 ]
 
 for name in __all__:

--- a/loraflexsim/launcher/adr_max.py
+++ b/loraflexsim/launcher/adr_max.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from .simulator import Simulator
+
+
+def apply(sim: Simulator) -> None:
+    """Configure ADR variant adr_max."""
+    Simulator.MARGIN_DB = 15.0
+    sim.adr_node = True
+    sim.adr_server = True
+    sim.adr_method = "max"
+    sim.network_server.adr_enabled = True
+    sim.network_server.adr_method = "max"
+    for node in sim.nodes:
+        node.adr_ack_cnt = 0
+        node.adr_ack_limit = 64
+        node.adr_ack_delay = 32

--- a/loraflexsim/launcher/dashboard.py
+++ b/loraflexsim/launcher/dashboard.py
@@ -24,7 +24,7 @@ for path in (ROOT_DIR, REPO_ROOT):
 
 from launcher.simulator import Simulator  # noqa: E402
 from launcher.channel import Channel  # noqa: E402
-from launcher import adr_standard_1, adr_2, adr_3  # noqa: E402
+from launcher import adr_standard_1, adr_2, adr_3, adr_max  # noqa: E402
 
 # --- Initialisation Panel ---
 pn.extension("plotly", raw_css=[
@@ -132,6 +132,7 @@ adr_server_checkbox = pn.widgets.Checkbox(name="ADR serveur", value=True)
 adr1_button = pn.widgets.Button(name="adr_1", button_type="primary")
 adr2_button = pn.widgets.Button(name="adr_2")
 adr3_button = pn.widgets.Button(name="adr_3")
+adr_max_button = pn.widgets.Button(name="adr_max")
 adr_active_badge = pn.pane.HTML("", width=80)
 
 # --- Choix SF et puissance initiaux identiques ---
@@ -536,14 +537,16 @@ def select_adr(module, name: str) -> None:
     adr_node_checkbox.value = True
     adr_server_checkbox.value = True
     _update_adr_badge(name)
-    for btn in (adr1_button, adr2_button, adr3_button):
+    for btn in (adr1_button, adr2_button, adr3_button, adr_max_button):
         btn.button_type = "default"
     if name == "ADR 1":
         adr1_button.button_type = "primary"
     elif name == "ADR 2":
         adr2_button.button_type = "primary"
-    else:
+    elif name == "ADR 3":
         adr3_button.button_type = "primary"
+    else:
+        adr_max_button.button_type = "primary"
     if sim is not None:
         if module is adr_standard_1:
             module.apply(sim, degrade_channel=True, profile="flora")
@@ -1227,6 +1230,7 @@ show_paths_checkbox.param.watch(lambda event: update_map(), "value")
 adr1_button.on_click(lambda event: select_adr(adr_standard_1, "ADR 1"))
 adr2_button.on_click(lambda event: select_adr(adr_2, "ADR 2"))
 adr3_button.on_click(lambda event: select_adr(adr_3, "ADR 3"))
+adr_max_button.on_click(lambda event: select_adr(adr_max, "ADR MAX"))
 
 # --- Associer les callbacks aux boutons ---
 start_button.on_click(on_start)
@@ -1246,7 +1250,7 @@ controls = pn.WidgetBox(
     num_runs_input,
     adr_node_checkbox,
     adr_server_checkbox,
-    pn.Row(adr1_button, adr2_button, adr3_button, adr_active_badge),
+    pn.Row(adr1_button, adr2_button, adr3_button, adr_max_button, adr_active_badge),
     fixed_sf_checkbox,
     sf_value_input,
     fixed_power_checkbox,

--- a/loraflexsim/launcher/tests/test_adr_max.py
+++ b/loraflexsim/launcher/tests/test_adr_max.py
@@ -1,0 +1,22 @@
+import random
+from loraflexsim.launcher import adr_max
+from loraflexsim.launcher.simulator import Simulator
+
+
+def test_adr_max_sets_max_method():
+    random.seed(0)
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        transmission_mode="Periodic",
+        packet_interval=1.0,
+        duty_cycle=None,
+        mobility=False,
+        seed=42,
+    )
+    adr_max.apply(sim)
+    assert sim.adr_node is True
+    assert sim.adr_server is True
+    assert sim.network_server.adr_enabled is True
+    assert sim.adr_method == "max"
+    assert sim.network_server.adr_method == "max"


### PR DESCRIPTION
## Summary
- add adr_max profile enabling ADR with max SNR method
- expose adr_max in package init and dashboard with selectable button
- cover adr_max in unit tests

## Testing
- `PYTHONPATH=. pytest loraflexsim/launcher/tests/test_adr_max.py loraflexsim/launcher/tests/test_adr.py`


------
https://chatgpt.com/codex/tasks/task_e_68c172c8600c833193e3770824a23dc1