### PR TITLE
Add ADR-Lite profile and dashboard button

### DIFF
--- a/loraflexsim/launcher/__init__.py
+++ b/loraflexsim/launcher/__init__.py
@@ -22,7 +22,7 @@ from .omnet_model import OmnetModel
 from .omnet_phy import OmnetPHY
 from .flora_cpp import FloraCppPHY
 from .obstacle_loss import ObstacleLoss
-from . import adr_standard_1, adr_2, adr_3, explora_sf, explora_at
+from . import adr_standard_1, adr_2, adr_3, explora_sf, explora_at, adr_lite
 
 __all__ = [
     "Node",
@@ -54,6 +54,7 @@ __all__ = [
     "adr_standard_1",
     "adr_2",
     "adr_3",
+    "adr_lite",
     "explora_sf",
     "explora_at",
 ]

--- a/loraflexsim/launcher/adr_lite.py
+++ b/loraflexsim/launcher/adr_lite.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from .simulator import Simulator
+from .channel import Channel
+from .lorawan import TX_POWER_INDEX_TO_DBM
+
+
+def apply(sim: Simulator) -> None:
+    """Configure simplified ADR-Lite parameters."""
+    Simulator.MARGIN_DB = 15.0
+    sim.adr_node = True
+    sim.adr_server = True
+    sim.adr_method = "max"
+    sim.network_server.adr_enabled = True
+    sim.network_server.adr_method = "adr-lite"
+
+    for node in sim.nodes:
+        if getattr(sim, "fixed_sf", None) is None:
+            node.sf = 12
+        node.initial_sf = node.sf
+        node.channel.detection_threshold_dBm = Channel.flora_detection_threshold(
+            node.sf, node.channel.bandwidth
+        ) + node.channel.sensitivity_margin_dB
+        max_tx_power = TX_POWER_INDEX_TO_DBM[0]
+        node.tx_power = max_tx_power
+        node.initial_tx_power = max_tx_power
+        node.adr_ack_cnt = 0
+        node.adr_ack_limit = 64
+        node.adr_ack_delay = 32
+
+    for ch in sim.multichannel.channels:
+        ch.detection_threshold_dBm = Channel.flora_detection_threshold(
+            12, ch.bandwidth
+        ) + ch.sensitivity_margin_dB

--- a/loraflexsim/launcher/dashboard.py
+++ b/loraflexsim/launcher/dashboard.py
@@ -24,7 +24,7 @@ for path in (ROOT_DIR, REPO_ROOT):
 
 from launcher.simulator import Simulator  # noqa: E402
 from launcher.channel import Channel  # noqa: E402
-from launcher import adr_standard_1, adr_2, adr_3, explora_sf, explora_at  # noqa: E402
+from launcher import adr_standard_1, adr_2, adr_3, explora_sf, explora_at, adr_lite  # noqa: E402
 
 # --- Initialisation Panel ---
 pn.extension("plotly", raw_css=[
@@ -135,6 +135,7 @@ adr2_button = pn.widgets.Button(name="adr_2")
 adr3_button = pn.widgets.Button(name="adr_3")
 explora_sf_button = pn.widgets.Button(name="EXPLoRa-SF")
 explora_at_button = pn.widgets.Button(name="EXPLoRa-AT")
+adr_lite_button = pn.widgets.Button(name="ADR-Lite")
 adr_active_badge = pn.pane.HTML("", width=80)
 
 # --- Choix SF et puissance initiaux identiques ---
@@ -539,7 +540,14 @@ def select_adr(module, name: str) -> None:
     adr_node_checkbox.value = True
     adr_server_checkbox.value = True
     _update_adr_badge(name)
-    for btn in (adr1_button, adr2_button, adr3_button, explora_sf_button, explora_at_button):
+    for btn in (
+        adr1_button,
+        adr2_button,
+        adr3_button,
+        explora_sf_button,
+        explora_at_button,
+        adr_lite_button,
+    ):
         btn.button_type = "default"
     if name == "ADR 1":
         adr1_button.button_type = "primary"
@@ -549,8 +557,10 @@ def select_adr(module, name: str) -> None:
         adr3_button.button_type = "primary"
     elif name == "EXPLoRa-SF":
         explora_sf_button.button_type = "primary"
-    else:
+    elif name == "EXPLoRa-AT":
         explora_at_button.button_type = "primary"
+    elif name == "ADR-Lite":
+        adr_lite_button.button_type = "primary"
     if sim is not None:
         if module is adr_standard_1:
             module.apply(sim, degrade_channel=True, profile="flora")
@@ -1236,6 +1246,7 @@ adr2_button.on_click(lambda event: select_adr(adr_2, "ADR 2"))
 adr3_button.on_click(lambda event: select_adr(adr_3, "ADR 3"))
 explora_sf_button.on_click(lambda event: select_adr(explora_sf, "EXPLoRa-SF"))
 explora_at_button.on_click(lambda event: select_adr(explora_at, "EXPLoRa-AT"))
+adr_lite_button.on_click(lambda event: select_adr(adr_lite, "ADR-Lite"))
 
 # --- Associer les callbacks aux boutons ---
 start_button.on_click(on_start)
@@ -1255,7 +1266,15 @@ controls = pn.WidgetBox(
     num_runs_input,
     adr_node_checkbox,
     adr_server_checkbox,
-    pn.Row(adr1_button, adr2_button, adr3_button, explora_sf_button, explora_at_button, adr_active_badge),
+    pn.Row(
+        adr1_button,
+        adr2_button,
+        adr3_button,
+        explora_sf_button,
+        explora_at_button,
+        adr_lite_button,
+        adr_active_badge,
+    ),
     fixed_sf_checkbox,
     sf_value_input,
     fixed_power_checkbox,

--- a/loraflexsim/launcher/tests/test_adr_lite.py
+++ b/loraflexsim/launcher/tests/test_adr_lite.py
@@ -1,0 +1,30 @@
+from loraflexsim.launcher.simulator import Simulator
+from loraflexsim.launcher.channel import Channel
+from loraflexsim.launcher.lorawan import TX_POWER_INDEX_TO_DBM
+from loraflexsim.launcher import adr_lite
+
+
+def test_adr_lite_apply_configures_simulator():
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        transmission_mode="Periodic",
+        packet_interval=1.0,
+        mobility=False,
+        adr_node=False,
+        adr_server=False,
+        duty_cycle=None,
+        seed=1,
+    )
+    adr_lite.apply(sim)
+    node = sim.nodes[0]
+    assert sim.adr_node is True
+    assert sim.adr_server is True
+    assert sim.network_server.adr_enabled is True
+    assert sim.network_server.adr_method == "adr-lite"
+    assert node.sf == 12
+    expected_thr = Channel.flora_detection_threshold(12, node.channel.bandwidth) + node.channel.sensitivity_margin_dB
+    assert node.channel.detection_threshold_dBm == expected_thr
+    assert node.tx_power == TX_POWER_INDEX_TO_DBM[0]
+    assert node.adr_ack_limit == 64
+    assert node.adr_ack_delay == 32


### PR DESCRIPTION
## Summary
- add ADR-Lite simulator configuration helper
- expose ADR-Lite in launcher package and dashboard
- test ADR-Lite setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c17fb499088331b3501f348cb0db0c