### PR TITLE
Add ADR-Max algorithm and dashboard support

### DIFF
--- a/loraflexsim/launcher/__init__.py
+++ b/loraflexsim/launcher/__init__.py
@@ -22,7 +22,15 @@ from .omnet_model import OmnetModel
 from .omnet_phy import OmnetPHY
 from .flora_cpp import FloraCppPHY
 from .obstacle_loss import ObstacleLoss
-from . import adr_standard_1, adr_2, adr_3, explora_sf, explora_at, adr_lite
+from . import (
+    adr_standard_1,
+    adr_2,
+    adr_3,
+    explora_sf,
+    explora_at,
+    adr_lite,
+    adr_max,
+)
 
 __all__ = [
     "Node",
@@ -57,6 +65,7 @@ __all__ = [
     "adr_lite",
     "explora_sf",
     "explora_at",
+    "adr_max",
 ]
 
 for name in __all__:

--- a/loraflexsim/launcher/adr_max.py
+++ b/loraflexsim/launcher/adr_max.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from .simulator import Simulator
+from .channel import Channel
+
+
+def apply(sim: Simulator) -> None:
+    """Configure the ADR-Max algorithm.
+
+    ADR-Max selects the highest spreading factor that still supports the link.
+    Nodes start with a conservative configuration so that the network server
+    can later optimise the spreading factor based on the measured SNR of the
+    first uplinks.
+    """
+    # Installation margin used both by the simulator and the network server
+    Simulator.MARGIN_DB = 15.0
+    from . import server as ns
+
+    ns.MARGIN_DB = 15.0
+
+    sim.adr_node = True
+    sim.adr_server = True
+    sim.network_server.adr_enabled = True
+    sim.network_server.adr_method = "adr-max"
+
+    for node in sim.nodes:
+        node.sf = 12
+        node.initial_sf = 12
+        node.channel.detection_threshold_dBm = (
+            Channel.flora_detection_threshold(node.sf, node.channel.bandwidth)
+            + node.channel.sensitivity_margin_dB
+        )
+        node.tx_power = 14.0
+        node.initial_tx_power = 14.0
+        node.adr_ack_cnt = 0
+        node.adr_ack_limit = 64
+        node.adr_ack_delay = 32
+
+    for ch in sim.multichannel.channels:
+        ch.detection_threshold_dBm = (
+            Channel.flora_detection_threshold(12, ch.bandwidth)
+            + ch.sensitivity_margin_dB
+        )

--- a/loraflexsim/launcher/dashboard.py
+++ b/loraflexsim/launcher/dashboard.py
@@ -24,7 +24,15 @@ for path in (ROOT_DIR, REPO_ROOT):
 
 from launcher.simulator import Simulator  # noqa: E402
 from launcher.channel import Channel  # noqa: E402
-from launcher import adr_standard_1, adr_2, adr_3, explora_sf, explora_at, adr_lite  # noqa: E402
+from launcher import (
+    adr_standard_1,
+    adr_2,
+    adr_3,
+    explora_sf,
+    explora_at,
+    adr_lite,
+    adr_max,
+)  # noqa: E402
 
 # --- Initialisation Panel ---
 pn.extension("plotly", raw_css=[
@@ -136,6 +144,7 @@ adr3_button = pn.widgets.Button(name="adr_3")
 explora_sf_button = pn.widgets.Button(name="EXPLoRa-SF")
 explora_at_button = pn.widgets.Button(name="EXPLoRa-AT")
 adr_lite_button = pn.widgets.Button(name="ADR-Lite")
+adr_max_button = pn.widgets.Button(name="ADR-Max")
 adr_active_badge = pn.pane.HTML("", width=80)
 
 # --- Choix SF et puissance initiaux identiques ---
@@ -547,6 +556,7 @@ def select_adr(module, name: str) -> None:
         explora_sf_button,
         explora_at_button,
         adr_lite_button,
+        adr_max_button,
     ):
         btn.button_type = "default"
     if name == "ADR 1":
@@ -561,6 +571,8 @@ def select_adr(module, name: str) -> None:
         explora_at_button.button_type = "primary"
     elif name == "ADR-Lite":
         adr_lite_button.button_type = "primary"
+    elif name == "ADR-Max":
+        adr_max_button.button_type = "primary"
     if sim is not None:
         if module is adr_standard_1:
             module.apply(sim, degrade_channel=True, profile="flora")
@@ -1247,6 +1259,7 @@ adr3_button.on_click(lambda event: select_adr(adr_3, "ADR 3"))
 explora_sf_button.on_click(lambda event: select_adr(explora_sf, "EXPLoRa-SF"))
 explora_at_button.on_click(lambda event: select_adr(explora_at, "EXPLoRa-AT"))
 adr_lite_button.on_click(lambda event: select_adr(adr_lite, "ADR-Lite"))
+adr_max_button.on_click(lambda event: select_adr(adr_max, "ADR-Max"))
 
 # --- Associer les callbacks aux boutons ---
 start_button.on_click(on_start)
@@ -1273,6 +1286,7 @@ controls = pn.WidgetBox(
         explora_sf_button,
         explora_at_button,
         adr_lite_button,
+        adr_max_button,
         adr_active_badge,
     ),
     fixed_sf_checkbox,

--- a/loraflexsim/launcher/server.py
+++ b/loraflexsim/launcher/server.py
@@ -439,6 +439,31 @@ class NetworkServer:
                                 node.nb_trans,
                             ),
                         )
+                elif self.adr_method == "adr-max":
+                    # ADR-Max : choisir le SF le plus élevé supportant le lien
+                    optimal_sf = 7
+                    for sf in range(12, 6, -1):
+                        required = REQUIRED_SNR.get(sf, -20.0) + MARGIN_DB
+                        if snr >= required:
+                            optimal_sf = sf
+                            break
+                    if optimal_sf != node.sf:
+                        node.sf = optimal_sf
+                        node.channel.detection_threshold_dBm = (
+                            Channel.flora_detection_threshold(
+                                node.sf, node.channel.bandwidth
+                            )
+                            + node.channel.sensitivity_margin_dB
+                        )
+                        self.send_downlink(
+                            node,
+                            adr_command=(
+                                optimal_sf,
+                                node.tx_power,
+                                node.chmask,
+                                node.nb_trans,
+                            ),
+                        )
                 else:
                     from .lorawan import (
                         DBM_TO_TX_POWER_INDEX,

--- a/loraflexsim/launcher/tests/test_adr_max.py
+++ b/loraflexsim/launcher/tests/test_adr_max.py
@@ -1,0 +1,29 @@
+from loraflexsim.launcher.simulator import Simulator
+from loraflexsim.launcher.channel import Channel
+from loraflexsim.launcher import adr_max
+
+
+def test_adr_max_apply_configures_simulator():
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        transmission_mode="Periodic",
+        packet_interval=1.0,
+        duty_cycle=None,
+        mobility=False,
+        adr_node=False,
+        adr_server=False,
+        seed=1,
+    )
+    adr_max.apply(sim)
+    node = sim.nodes[0]
+    assert sim.adr_node is True
+    assert sim.adr_server is True
+    assert sim.network_server.adr_enabled is True
+    assert sim.network_server.adr_method == "adr-max"
+    assert node.sf == 12
+    expected_thr = Channel.flora_detection_threshold(12, node.channel.bandwidth) + node.channel.sensitivity_margin_dB
+    assert node.channel.detection_threshold_dBm == expected_thr
+    assert node.tx_power == 14.0
+    assert node.adr_ack_limit == 64
+    assert node.adr_ack_delay == 32


### PR DESCRIPTION
## Summary
- add ADR-Max setup selecting highest spreading factor per link
- expose adr_max in launcher and dashboard
- implement server-side ADR-Max logic and tests

## Testing
- `PYTHONPATH=$PWD pytest loraflexsim/launcher/tests/test_adr_max.py loraflexsim/launcher/tests/test_dashboard_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68c181e2547c833187570acadf6419b7