### PR TITLE
Add RADR reinforcement learning ADR framework

### DIFF
--- a/loraflexsim/launcher/__init__.py
+++ b/loraflexsim/launcher/__init__.py
@@ -30,6 +30,7 @@ from . import (
     explora_at,
     adr_lite,
     adr_max,
+    radr,
 )
 
 __all__ = [
@@ -66,6 +67,7 @@ __all__ = [
     "explora_sf",
     "explora_at",
     "adr_max",
+    "radr",
 ]
 
 for name in __all__:

--- a/loraflexsim/launcher/dashboard.py
+++ b/loraflexsim/launcher/dashboard.py
@@ -32,6 +32,7 @@ from launcher import (
     explora_at,
     adr_lite,
     adr_max,
+    radr,
 )  # noqa: E402
 
 # --- Initialisation Panel ---
@@ -145,6 +146,7 @@ explora_sf_button = pn.widgets.Button(name="EXPLoRa-SF")
 explora_at_button = pn.widgets.Button(name="EXPLoRa-AT")
 adr_lite_button = pn.widgets.Button(name="ADR-Lite")
 adr_max_button = pn.widgets.Button(name="ADR-Max")
+radr_button = pn.widgets.Button(name="RADR")
 adr_active_badge = pn.pane.HTML("", width=80)
 
 # --- Choix SF et puissance initiaux identiques ---
@@ -557,6 +559,7 @@ def select_adr(module, name: str) -> None:
         explora_at_button,
         adr_lite_button,
         adr_max_button,
+        radr_button,
     ):
         btn.button_type = "default"
     if name == "ADR 1":
@@ -573,6 +576,8 @@ def select_adr(module, name: str) -> None:
         adr_lite_button.button_type = "primary"
     elif name == "ADR-Max":
         adr_max_button.button_type = "primary"
+    elif name == "RADR":
+        radr_button.button_type = "primary"
     if sim is not None:
         if module is adr_standard_1:
             module.apply(sim, degrade_channel=True, profile="flora")
@@ -1260,6 +1265,7 @@ explora_sf_button.on_click(lambda event: select_adr(explora_sf, "EXPLoRa-SF"))
 explora_at_button.on_click(lambda event: select_adr(explora_at, "EXPLoRa-AT"))
 adr_lite_button.on_click(lambda event: select_adr(adr_lite, "ADR-Lite"))
 adr_max_button.on_click(lambda event: select_adr(adr_max, "ADR-Max"))
+radr_button.on_click(lambda event: select_adr(radr, "RADR"))
 
 # --- Associer les callbacks aux boutons ---
 start_button.on_click(on_start)
@@ -1287,6 +1293,7 @@ controls = pn.WidgetBox(
         explora_at_button,
         adr_lite_button,
         adr_max_button,
+        radr_button,
         adr_active_badge,
     ),
     fixed_sf_checkbox,

--- a/loraflexsim/launcher/radr.py
+++ b/loraflexsim/launcher/radr.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Tuple
+
+from .simulator import Simulator
+
+
+@dataclass
+class RADRModel:
+    """Minimal reinforcement learning model for RADR.
+
+    The model maintains a simple table of cumulative rewards for
+    state-action pairs.  It is intentionally lightweight and serves as a
+    placeholder for a more advanced learning algorithm.
+    """
+
+    q_table: Dict[Tuple[Tuple, str], float] = field(default_factory=dict)
+
+    def update(self, state: Tuple, action: str, reward: float) -> None:
+        """Update the cumulative reward for a given state and action."""
+        key = (state, action)
+        self.q_table[key] = self.q_table.get(key, 0.0) + reward
+
+    def best_action(self, state: Tuple) -> str:
+        """Return the best known action for *state* (placeholder)."""
+        candidates = {a: r for (s, a), r in self.q_table.items() if s == state}
+        if not candidates:
+            return "default"
+        return max(candidates, key=candidates.get)
+
+
+def apply(sim: Simulator) -> None:
+    """Configure the RADR ADR method using reinforcement learning."""
+    sim.network_server.adr_method = "radr"
+    sim.network_server.adr_model = RADRModel()
+
+    def reward_callback(state: Tuple, action: str, success: bool) -> None:
+        """Simple reward handler updating the RADR model.
+
+        Parameters
+        ----------
+        state: Tuple
+            Representation of the current environment state.
+        action: str
+            Action chosen by the ADR algorithm.
+        success: bool
+            Whether the transmission was successful.
+        """
+        reward = 1.0 if success else -1.0
+        sim.network_server.adr_model.update(state, action, reward)
+
+    sim.network_server.adr_reward = reward_callback

--- a/loraflexsim/launcher/tests/test_radr.py
+++ b/loraflexsim/launcher/tests/test_radr.py
@@ -1,0 +1,26 @@
+from loraflexsim.launcher.simulator import Simulator
+from loraflexsim.launcher import radr
+
+
+def test_radr_apply_and_model_update():
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        transmission_mode="Periodic",
+        packet_interval=1.0,
+        mobility=False,
+        adr_node=False,
+        adr_server=False,
+        duty_cycle=None,
+        seed=1,
+    )
+    radr.apply(sim)
+    assert sim.network_server.adr_method == "radr"
+    assert hasattr(sim.network_server, "adr_model")
+
+    state = ("s",)
+    action = "a"
+    sim.network_server.adr_reward(state, action, True)
+    assert sim.network_server.adr_model.q_table[(state, action)] == 1.0
+    sim.network_server.adr_reward(state, action, False)
+    assert sim.network_server.adr_model.q_table[(state, action)] == 0.0


### PR DESCRIPTION
## Summary
- add RADR ADR method skeleton with simple reinforcement learning model
- expose RADR in launcher package and dashboard interface
- test RADR model configuration and update behavior

## Testing
- `PYTHONPATH=$PWD pytest loraflexsim/launcher/tests/test_radr.py`

------
https://chatgpt.com/codex/tasks/task_e_68c184118e548331a7fcac3c563a7643