### PR TITLE
docs: add ADR protocol overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Bienvenue ! **LoRaFlexSim** est un **simulateur complet de réseau LoRa**, inspiré du fonctionnement de FLoRa sous OMNeT++, codé entièrement en Python.
 Pour un aperçu des différences avec FLoRa, consultez docs/lorawan_features.md.
 Les principales équations sont décrites dans docs/equations_flora.md.
+Une synthèse des protocoles ADR est disponible dans docs/adr_protocols.md.
 
 Par défaut, le module `Channel` charge la table de bruit de FLoRa en analysant
 `flora-master/src/LoRaPhy/LoRaAnalogModel.cc` si le fichier est présent. Cette

--- a/docs/adr_protocols.md
+++ b/docs/adr_protocols.md
@@ -1,0 +1,13 @@
+# Protocoles ADR LoRa
+
+Cette page résume plusieurs stratégies d'Adaptive Data Rate (ADR) pour LoRaWAN.
+
+| Protocole | Principe général | Machine learning | Avantages | Limites |
+|-----------|-----------------|-----------------|-----------|---------|
+| ADR standard | Algorithme LoRaWAN basé sur l'historique SNR pour ajuster SF et puissance. | Non | Simple, conforme à la spécification, faible surcharge réseau. | Réagit lentement, peu adapté aux nœuds mobiles ou aux environnements très variables. |
+| EXPLoRa-SF | Allocation équitable du spreading factor pour maximiser le débit global. | Non | Améliore l'équité entre nœuds, réduit les collisions. | Nécessite une coordination centrale, peut augmenter la latence pour certains nœuds. |
+| EXPLoRa-AT | Extension d'EXPLoRa optimisant SF et temps d'accès pour équilibrer l'occupation du canal. | Non | Meilleure utilisation du temps d'antenne, réduit la congestion. | Complexité accrue, besoin de synchronisation précise. |
+| ADR-Lite | Version simplifiée avec seuils SNR fixes pour un ajustement rapide. | Non | Faible calcul côté serveur, adaptation rapide. | Moins précise, risque d'augmentation de la consommation ou des collisions. |
+| ADR-Max | Algorithme agressif visant à maximiser la capacité en explorant les débits élevés. | Non | Maximisation du débit lorsque le lien est bon. | Sensible aux dégradations soudaines, instabilité possible pour les liens faibles. |
+| RADR | ADR réactif ajustant SF et puissance à chaque message selon la dernière qualité du lien. | Non | Très réactif aux variations, adapté aux scénarios de mobilité. | Mesures bruyantes entraînant des oscillations, nécessite plus de signalisations. |
+| ADR_ML | Modèle fondé sur le machine learning pour prédire SF et puissance à partir des caractéristiques du lien. | Oui | Peut s'adapter à des scénarios complexes, performances potentielles supérieures. | Besoin de données d'entraînement, coût computationnel, explicabilité limitée. |


### PR DESCRIPTION
## Summary
- document ADR strategies in new `docs/adr_protocols.md`
- link to ADR comparison from README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1890d172c83318695c6ca466f1d30