### PR TITLE
Reject infinite intervals in simulation inputs

### DIFF
--- a/loraflexsim/run.py
+++ b/loraflexsim/run.py
@@ -2,6 +2,7 @@ import argparse
 import configparser
 import csv
 import numbers
+import math
 
 from traffic.exponential import sample_interval
 from traffic.rng_manager import RngManager
@@ -65,12 +66,14 @@ def simulate(
         isinstance(interval, numbers.Real)
         and not isinstance(interval, numbers.Integral)
         and interval > 0
+        and math.isfinite(interval)
     ):
         raise ValueError("interval must be a positive float")
     if first_interval is not None and not (
         isinstance(first_interval, numbers.Real)
         and not isinstance(first_interval, numbers.Integral)
         and first_interval > 0
+        and math.isfinite(first_interval)
     ):
         raise ValueError("first_interval must be positive float")
     if steps <= 0:

--- a/tests/test_infinite_params.py
+++ b/tests/test_infinite_params.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+
+from traffic.exponential import sample_interval, sample_exp
+from loraflexsim.run import simulate
+from traffic.rng_manager import RngManager
+
+
+def _rng():
+    return np.random.Generator(np.random.MT19937(0))
+
+
+def test_sample_interval_rejects_infinite_mean():
+    with pytest.raises(ValueError):
+        sample_interval(float('inf'), _rng())
+
+
+def test_sample_exp_rejects_infinite_mean():
+    with pytest.raises(ValueError):
+        sample_exp(float('inf'), _rng())
+
+
+def test_simulate_rejects_infinite_interval():
+    rng = RngManager(0)
+    with pytest.raises(ValueError):
+        simulate(nodes=1, gateways=1, mode="Random", interval=float('inf'), steps=10, rng_manager=rng)
+
+
+def test_simulate_rejects_infinite_first_interval():
+    rng = RngManager(0)
+    with pytest.raises(ValueError):
+        simulate(nodes=1, gateways=1, mode="Periodic", interval=1.0, steps=10, first_interval=float('inf'), rng_manager=rng)

--- a/traffic/exponential.py
+++ b/traffic/exponential.py
@@ -32,6 +32,7 @@ def sample_interval(mean: float, rng: np.random.Generator) -> float:
         isinstance(mean, numbers.Real)
         and not isinstance(mean, numbers.Integral)
         and mean > 0
+        and math.isfinite(mean)
     ):
         raise ValueError("mean_interval must be positive float")
     mean = float(mean)
@@ -56,6 +57,7 @@ def sample_exp(mu_send: float, rng: np.random.Generator) -> float:
         isinstance(mu_send, numbers.Real)
         and not isinstance(mu_send, numbers.Integral)
         and mu_send > 0
+        and math.isfinite(mu_send)
     ):
         raise ValueError("mu_send must be positive float")
     mu_send = float(mu_send)


### PR DESCRIPTION
## Summary
- ensure exponential sampling and simulation intervals reject infinite values
- add tests confirming ValueError for infinite means and delays

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c18aa7212c8331b52b2847881eff73