### PR TITLE
feat: ensure explora-at default margin and sf

### DIFF
--- a/docs/adr_protocols.md
+++ b/docs/adr_protocols.md
@@ -11,3 +11,11 @@ Cette page résume plusieurs stratégies d'Adaptive Data Rate (ADR) pour LoRaWAN
 | ADR-Max | Algorithme agressif visant à maximiser la capacité en explorant les débits élevés. | Non | Maximisation du débit lorsque le lien est bon. | Sensible aux dégradations soudaines, instabilité possible pour les liens faibles. |
 | RADR | ADR réactif ajustant SF et puissance à chaque message selon la dernière qualité du lien. | Non | Très réactif aux variations, adapté aux scénarios de mobilité. | Mesures bruyantes entraînant des oscillations, nécessite plus de signalisations. |
 | ADR_ML | Modèle fondé sur le machine learning pour prédire SF et puissance à partir des caractéristiques du lien. | Oui | Peut s'adapter à des scénarios complexes, performances potentielles supérieures. | Besoin de données d'entraînement, coût computationnel, explicabilité limitée. |
+
+## EXPLoRa-AT
+
+Cette variante d'EXPLoRa initialise tous les nœuds avec une marge
+d'installation de 10 dB et le spreading factor SF12. Chaque nœud émet
+ainsi à puissance maximale et l'algorithme ajuste ensuite SF et puissance
+en fonction du SNR mesuré lors des premiers uplinks pour équilibrer
+l'occupation du canal.

--- a/loraflexsim/launcher/explora_at.py
+++ b/loraflexsim/launcher/explora_at.py
@@ -13,8 +13,8 @@ def apply(sim: Simulator) -> None:
     network server can later optimise these values based on the measured SNR
     of the first uplinks.
     """
-    # Typical installation margin for EXPLoRa-AT. Both the simulator and
-    # the network server rely on this constant when evaluating SNR margins.
+    # Typical installation margin for EXPLoRa-AT. Both the simulator and the
+    # network server rely on this constant when evaluating SNR margins.
     Simulator.MARGIN_DB = 10.0
     from . import server as ns
 
@@ -29,14 +29,12 @@ def apply(sim: Simulator) -> None:
         # Start with the most robust SF so that connectivity is guaranteed
         # before the server sends optimised parameters based on the first
         # measurements.
-        node.sf = 12
-        node.initial_sf = 12
+        node.sf = node.initial_sf = 12
         node.channel.detection_threshold_dBm = (
             Channel.flora_detection_threshold(node.sf, node.channel.bandwidth)
             + node.channel.sensitivity_margin_dB
         )
-        node.tx_power = 14.0
-        node.initial_tx_power = 14.0
+        node.tx_power = node.initial_tx_power = 14.0
         node.adr_ack_cnt = 0
         node.adr_ack_limit = 64
         node.adr_ack_delay = 32

--- a/loraflexsim/launcher/tests/test_explora_at.py
+++ b/loraflexsim/launcher/tests/test_explora_at.py
@@ -1,5 +1,6 @@
 from loraflexsim.launcher.simulator import Simulator
-from loraflexsim.launcher import explora_at
+from loraflexsim.launcher.channel import Channel
+from loraflexsim.launcher import explora_at, server
 
 
 def test_explora_at_enables_adr_and_sets_method():
@@ -18,3 +19,24 @@ def test_explora_at_enables_adr_and_sets_method():
     assert sim.adr_node is True
     assert sim.adr_server is True
     assert sim.network_server.adr_method == "explora-at"
+
+
+def test_explora_at_initialisation_margin_and_sf():
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        transmission_mode="Periodic",
+        packet_interval=1.0,
+        duty_cycle=None,
+        mobility=False,
+        adr_node=False,
+        adr_server=False,
+        seed=1,
+    )
+    explora_at.apply(sim)
+    node = sim.nodes[0]
+    assert Simulator.MARGIN_DB == 10.0
+    assert server.MARGIN_DB == 10.0
+    assert node.sf == node.initial_sf == 12
+    expected_thr = Channel.flora_detection_threshold(12, node.channel.bandwidth) + node.channel.sensitivity_margin_dB
+    assert node.channel.detection_threshold_dBm == expected_thr


### PR DESCRIPTION
## Summary
- refine EXPLoRa-AT ADR setup and default parameters
- verify EXPLoRa-AT margin and initial SF in tests
- document EXPLoRa-AT behaviour in ADR protocol docs

## Testing
- `PYTHONPATH=. pytest loraflexsim/launcher/tests/test_explora_at.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1a0473ec4833186bf848662584181