### PR TITLE
feat: enhance RADR with simple RL

### DIFF
--- a/docs/adr_protocols.md
+++ b/docs/adr_protocols.md
@@ -9,7 +9,7 @@ Cette page résume plusieurs stratégies d'Adaptive Data Rate (ADR) pour LoRaWAN
 | EXPLoRa-AT | Extension d'EXPLoRa optimisant SF et temps d'accès pour équilibrer l'occupation du canal. | Non | Meilleure utilisation du temps d'antenne, réduit la congestion. | Complexité accrue, besoin de synchronisation précise. |
 | ADR-Lite | Version simplifiée avec seuils SNR fixes pour un ajustement rapide. | Non | Faible calcul côté serveur, adaptation rapide. | Moins précise, risque d'augmentation de la consommation ou des collisions. |
 | ADR-Max | Sélection agressive du spreading factor maximal supporté. | Non | Robustesse accrue et portée maximale. | Temps d'antenne long, capacité réseau réduite, risque de congestion. |
-| RADR | ADR réactif ajustant SF et puissance à chaque message selon la dernière qualité du lien. | Non | Très réactif aux variations, adapté aux scénarios de mobilité. | Mesures bruyantes entraînant des oscillations, nécessite plus de signalisations. |
+| RADR | ADR réactif ajustant SF et puissance à chaque message selon la dernière qualité du lien. | Oui | Très réactif aux variations, adapté aux scénarios de mobilité. | Mesures bruyantes entraînant des oscillations, nécessite plus de signalisations. |
 | ADR_ML | Modèle fondé sur le machine learning pour prédire SF et puissance à partir des caractéristiques du lien. | Oui | Peut s'adapter à des scénarios complexes, performances potentielles supérieures. | Besoin de données d'entraînement, coût computationnel, explicabilité limitée. |
 
 L'algorithme **ADR-Lite** n'emploie aucun procédé de machine learning : il se contente de comparer le SNR mesuré à des seuils fixes pour ajuster rapidement le spreading factor.

--- a/loraflexsim/launcher/tests/test_radr.py
+++ b/loraflexsim/launcher/tests/test_radr.py
@@ -1,9 +1,9 @@
 from loraflexsim.launcher.simulator import Simulator
-from loraflexsim.launcher import radr
+from loraflexsim.launcher import radr, ADR_MODULES
 
 
-def test_radr_apply_and_model_update():
-    sim = Simulator(
+def make_simulator():
+    return Simulator(
         num_nodes=1,
         num_gateways=1,
         transmission_mode="Periodic",
@@ -14,13 +14,33 @@ def test_radr_apply_and_model_update():
         duty_cycle=None,
         seed=1,
     )
+
+
+def test_radr_is_registered():
+    assert "RADR" in ADR_MODULES
+
+
+def test_radr_reward_and_action():
+    sim = make_simulator()
     radr.apply(sim)
     assert sim.network_server.adr_method == "radr"
     assert hasattr(sim.network_server, "adr_model")
 
-    state = ("s",)
-    action = "a"
-    sim.network_server.adr_reward(state, action, True)
-    assert sim.network_server.adr_model.q_table[(state, action)] == 1.0
-    sim.network_server.adr_reward(state, action, False)
-    assert sim.network_server.adr_model.q_table[(state, action)] == 0.0
+    sf = 12
+    snr = -2.0  # above REQUIRED_SNR + margin -> should decrease SF
+    action = sim.network_server.adr_action(snr, sf)
+    assert action == "sf_down"
+
+    sim.network_server.adr_reward(snr, sf, action)
+    state = (round(snr), sf)
+    expected = snr - Simulator.REQUIRED_SNR[sf]
+    assert sim.network_server.adr_model.q_table[(state, action)] == expected
+
+
+def test_radr_model_convergence():
+    model = radr.RADRModel()
+    state = (0, 12)
+    for _ in range(5):
+        model.update(state, "sf_down", 1.0)
+        model.update(state, "sf_up", -1.0)
+    assert model.best_action(state) == "sf_down"


### PR DESCRIPTION
## Summary
- integrate SNR-aware reward and action callbacks for RADR
- register RADR in ADR module mapping and add convergence tests
- document RADR as ML-based ADR protocol

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1a76a98288331a416736fcd7f3c6c