### PR TITLE
style: render trajectory lines in black

### DIFF
--- a/loraflexsim/launcher/dashboard.py
+++ b/loraflexsim/launcher/dashboard.py
@@ -332,7 +332,7 @@ def update_map():
         for path in node_paths.values():
             if len(path) > 1:
                 xs_p, ys_p = zip(*path)
-                fig.add_scatter(x=xs_p, y=ys_p, mode="lines", line=dict(color="lightblue", width=1), showlegend=False)
+                fig.add_scatter(x=xs_p, y=ys_p, mode="lines", line=dict(color="black", width=1), showlegend=False)
 
     # Dessiner les transmissions récentes
     for ev in sim.events_log[-20:]:


### PR DESCRIPTION
## Summary
- draw node trajectories in black on dashboard map

## Testing
- `python - <<'PY'
import loraflexsim.launcher.dashboard as db
class Node: ...
class GW: ...
class Sim: ...
sim = Sim()
db.sim = sim
db.node_paths.clear()
db.show_paths_checkbox.value = True
db.session_alive = lambda: True
db.update_map()
db.update_map()
fig = db.map_pane.object
colors = [trace.line.color for trace in fig.data if trace.mode == 'lines']
print('line colors:', colors)
PY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1bd724a848331a4ea76daba6c956e