### PR TITLE
Move plot legends above figures

### DIFF
--- a/scripts/plot_battery_tracking.py
+++ b/scripts/plot_battery_tracking.py
@@ -92,7 +92,8 @@ def main() -> None:
     ax.set_title("Temporal evolution of residual battery energy")
     ax.set_ylim(0, 100)
     ax.grid(True)
-    ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
+    ax.legend(loc="upper center", bbox_to_anchor=(0.5, 1.15), ncol=1)
+    fig.tight_layout(rect=[0, 0, 1, 0.9])
 
     os.makedirs(FIGURES_DIR, exist_ok=True)
     base = os.path.join(FIGURES_DIR, "battery_tracking")

--- a/scripts/plot_mobility_latency_energy.py
+++ b/scripts/plot_mobility_latency_energy.py
@@ -109,8 +109,8 @@ def plot(
             title += f"\n{param_text}"
         ax.set_title(title)
         ax.bar_label(bars, fmt=fmt, label_type="center")
-        ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
-        fig.tight_layout(rect=[0, 0.2, 0.9, 1])
+        ax.legend(loc="upper center", bbox_to_anchor=(0.5, 1.15), ncol=1)
+        fig.tight_layout(rect=[0, 0, 1, 0.9])
         stem = Path(filename).stem
         for ext in ("png", "jpg", "eps"):
             dpi = 300 if ext in ("png", "jpg") else None

--- a/scripts/plot_mobility_models.py
+++ b/scripts/plot_mobility_models.py
@@ -72,8 +72,8 @@ def plot(
 
         ax.set_title(f"{name} by model (0 ≤ {name} ≤ {cap:g} {unit})")
         ax.bar_label(bars, fmt=fmt, label_type="center")
-        ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
-        fig.tight_layout(rect=[0, 0.2, 0.9, 1])
+        ax.legend(loc="upper center", bbox_to_anchor=(0.5, 1.15), ncol=1)
+        fig.tight_layout(rect=[0, 0, 1, 0.9])
         for ext in ("png", "jpg", "eps"):
             dpi = 300 if ext in ("png", "jpg") else None
             fig.savefig(out_dir / f"{metric}_vs_model.{ext}", dpi=dpi)

--- a/scripts/plot_mobility_multichannel.py
+++ b/scripts/plot_mobility_multichannel.py
@@ -22,7 +22,8 @@ def plot(
     max_energy: float | None = None,
 ) -> None:
     df = pd.read_csv(csv_path)
-    plt.rcParams.update({"font.size": 16})
+    if hasattr(plt, "rcParams"):
+        plt.rcParams.update({"font.size": 16})
 
     if "scenario" not in df.columns:
         raise ValueError("CSV must contain a 'scenario' column")
@@ -77,7 +78,8 @@ def plot(
             df["scenario_label"], rotation=45, ha="right"
         )
         ax.set_ylabel(label)
-        ax.tick_params(axis="both", labelsize=16)
+        if hasattr(ax, "tick_params"):
+            ax.tick_params(axis="both", labelsize=16)
 
         if metric == "pdr":
             cap = 100.0
@@ -96,8 +98,8 @@ def plot(
         title = f"{name} by scenario (0 ≤ {name} ≤ {cap:g} {unit})"
         ax.set_title(title)
         ax.bar_label(bars, fmt=fmt, label_type="center")
-        ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
-        fig.tight_layout(rect=[0, 0.2, 0.9, 1])
+        ax.legend(loc="upper center", bbox_to_anchor=(0.5, 1.15), ncol=1)
+        fig.tight_layout(rect=[0, 0, 1, 0.9])
         for ext in ("png", "jpg", "eps"):
             dpi = 300 if ext in ("png", "jpg") else None
             fig.savefig(out_dir / f"{metric}_vs_scenario.{ext}", dpi=dpi)


### PR DESCRIPTION
## Summary
- Place legends above plots in analysis scripts
- Reserve top margin with `tight_layout` for new legend placement
- Avoid rcParams/tick_params calls when matplotlib stubs lack them

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6ef2084f08331a8a0618e5526a6eb