### PR TITLE
Ensure EPS export in plotting scripts

### DIFF
--- a/scripts/plot_node_positions.py
+++ b/scripts/plot_node_positions.py
@@ -86,9 +86,9 @@ def main(argv: list[str] | None = None) -> None:
     ax.set_xlabel("x")
     ax.set_ylabel("y")
     ax.set_title("Node positions")
-    for ext in (".png", ".jpg", ".eps"):
-        dpi = 300 if ext in (".png", ".jpg") else None
-        fig.savefig(output_path.with_suffix(ext), dpi=dpi)
+    for ext in ("png", "jpg", "eps"):
+        dpi = 300 if ext in ("png", "jpg") else None
+        fig.savefig(output_path.with_suffix(f".{ext}"), dpi=dpi)
     plt.close(fig)
 
 


### PR DESCRIPTION
## Summary
- Standardize node position plotting to export PNG, JPG, and EPS formats

## Testing
- `pytest`
- `python scripts/plot_node_positions.py --num-nodes 10 --area-size 100 --seed 42 --output temp_positions.png`

------
https://chatgpt.com/codex/tasks/task_e_68c6f1481d40833198a607306a504edb