### PR TITLE
Add SVG output to mobility plotting scripts

### DIFF
--- a/scripts/plot_mobility_latency_energy.py
+++ b/scripts/plot_mobility_latency_energy.py
@@ -112,7 +112,7 @@ def plot(
         ax.legend(loc="upper center", bbox_to_anchor=(0.5, 1.15), ncol=1)
         fig.tight_layout(rect=[0, 0, 1, 0.9])
         stem = Path(filename).stem
-        for ext in ("png", "jpg", "eps"):
+        for ext in ("png", "jpg", "eps", "svg"):
             dpi = 300 if ext in ("png", "jpg") else None
             fig.savefig(out_dir / f"{stem}.{ext}", dpi=dpi)
         plt.close(fig)

--- a/scripts/plot_mobility_multichannel.py
+++ b/scripts/plot_mobility_multichannel.py
@@ -100,7 +100,7 @@ def plot(
         ax.bar_label(bars, fmt=fmt, label_type="center")
         ax.legend(loc="upper center", bbox_to_anchor=(0.5, 1.15), ncol=1)
         fig.tight_layout(rect=[0, 0, 1, 0.9])
-        for ext in ("png", "jpg", "eps"):
+        for ext in ("png", "jpg", "eps", "svg"):
             dpi = 300 if ext in ("png", "jpg") else None
             fig.savefig(out_dir / f"{metric}_vs_scenario.{ext}", dpi=dpi)
         plt.close(fig)


### PR DESCRIPTION
## Summary
- Ensure mobility latency/energy plots also save SVG versions in addition to PNG/JPG/EPS
- Extend multichannel plotting script to export figures as SVG as well

## Testing
- `python scripts/plot_mobility_latency_energy.py results/mobility_latency_energy_agg.csv -o figures_new`
- `python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv` *(fails: KeyError: 'nodes')*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6f2b542e88331a6c7a2238473a1ee