### PR TITLE
Show node counts in mobility latency energy plots

### DIFF
--- a/scripts/plot_mobility_latency_energy.py
+++ b/scripts/plot_mobility_latency_energy.py
@@ -22,6 +22,12 @@ def plot(
     max_energy: float | None = None,
 ) -> None:
     df = pd.read_csv(csv_path)
+    if "nodes" in df.columns:
+        df["scenario_label"] = (
+            df["scenario"] + " (" + df["nodes"].astype(str) + " nodes)"
+        )
+    else:
+        df["scenario_label"] = df["scenario"]
     plt.rcParams.update({"font.size": 16})
 
     out_dir = Path(output_dir)
@@ -86,7 +92,7 @@ def plot(
         )
         ax.set_xlabel("Scenario")
         ax.set_xticks(range(len(df["scenario"])))
-        ax.set_xticklabels(df["scenario"], rotation=45, ha="right")
+        ax.set_xticklabels(df["scenario_label"], rotation=45, ha="right")
         ax.set_ylabel(label)
         ax.tick_params(axis="both", labelsize=16)
 


### PR DESCRIPTION
## Summary
- append a `scenario_label` column to combine scenario names with node counts
- display the new `scenario_label` on x-axis with rotated right-aligned labels

## Testing
- `pytest`
- `python scripts/run_mobility_latency_energy.py --nodes 5 --packets 2 --seed 1`
- `python scripts/plot_mobility_latency_energy.py /tmp/mobility_latency_energy.csv -o /tmp/figures`


------
https://chatgpt.com/codex/tasks/task_e_68c6f429c9c08331b88d1dae0fe7ec96