### PR TITLE
Validate positive distances for path loss

### DIFF
--- a/loraflexsim/launcher/channel.py
+++ b/loraflexsim/launcher/channel.py
@@ -18,8 +18,8 @@ def path_loss_hata_okumura(distance: float, k1: float, k2: float) -> float:
     """
 
     if distance <= 0:
-        return 0.0
-    d_km = max(distance, 1.0) / 1000.0
+        raise ValueError("distance must be > 0")
+    d_km = distance / 1000.0
     return k1 + k2 * math.log10(d_km)
 
 
@@ -37,9 +37,8 @@ def path_loss_oulu(
     """
 
     if distance <= 0:
-        return 0.0
-    d = max(distance, 1.0)
-    return b + 10 * n * math.log10(d / d0) - antenna_gain
+        raise ValueError("distance must be > 0")
+    return b + 10 * n * math.log10(distance / d0) - antenna_gain
 
 class _CorrelatedValue:
     """Correlated random walk used for optional impairments."""

--- a/tests/test_channel_path_loss_validation.py
+++ b/tests/test_channel_path_loss_validation.py
@@ -1,0 +1,15 @@
+import pytest
+
+from loraflexsim.launcher.channel import path_loss_hata_okumura, path_loss_oulu
+
+def test_hata_okumura_rejects_non_positive_distance():
+    with pytest.raises(ValueError):
+        path_loss_hata_okumura(0.0, 127.5, 35.2)
+    with pytest.raises(ValueError):
+        path_loss_hata_okumura(-10.0, 127.5, 35.2)
+
+def test_oulu_rejects_non_positive_distance():
+    with pytest.raises(ValueError):
+        path_loss_oulu(0.0, 128.95, 2.32, 1000.0, 2.0)
+    with pytest.raises(ValueError):
+        path_loss_oulu(-5.0, 128.95, 2.32, 1000.0, 2.0)


### PR DESCRIPTION
## Summary
- ensure path loss helpers raise ValueError for non-positive distances
- test path loss functions with invalid distances

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6f9f28dcc83318f23cdc0d6e3f112