### PR TITLE
Clarify mobility plot legends

### DIFF
--- a/scripts/plot_mobility_latency_energy.py
+++ b/scripts/plot_mobility_latency_energy.py
@@ -115,7 +115,12 @@ def plot(
             title += f"\n{param_text}"
         ax.set_title(title)
         ax.bar_label(bars, fmt=fmt, label_type="center")
-        ax.legend(loc="upper center", bbox_to_anchor=(0.5, 1.15), ncol=1)
+        ax.legend(
+            loc="upper center",
+            bbox_to_anchor=(0.5, 1.25),
+            ncol=1,
+            title="N : nombre de nœuds, C : nombre de canaux, speed : m/s",
+        )
         fig.tight_layout(rect=[0, 0, 1, 0.9])
         stem = Path(filename).stem
         for ext in ("png", "jpg", "eps", "svg"):

--- a/scripts/plot_mobility_multichannel.py
+++ b/scripts/plot_mobility_multichannel.py
@@ -98,7 +98,12 @@ def plot(
         title = f"{name} by scenario (0 ≤ {name} ≤ {cap:g} {unit})"
         ax.set_title(title)
         ax.bar_label(bars, fmt=fmt, label_type="center")
-        ax.legend(loc="upper center", bbox_to_anchor=(0.5, 1.15), ncol=1)
+        ax.legend(
+            loc="upper center",
+            bbox_to_anchor=(0.5, 1.25),
+            ncol=1,
+            title="N : nombre de nœuds, C : nombre de canaux, speed : m/s",
+        )
         fig.tight_layout(rect=[0, 0, 1, 0.9])
         for ext in ("png", "jpg", "eps", "svg"):
             dpi = 300 if ext in ("png", "jpg") else None


### PR DESCRIPTION
## Summary
- Raise legend position in `plot_mobility_multichannel.py` and `plot_mobility_latency_energy.py`
- Add legend title explaining abbreviations for node count, channel count, and speed

## Testing
- `python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv -o figures`
- `python scripts/plot_mobility_latency_energy.py results/mobility_latency_energy.csv -o figures`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c70fa54eb083319803bd76fc6a75e7