### PR TITLE
Remove Scenario x-axis label from mobility plots

### DIFF
--- a/scripts/plot_mobility_latency_energy.py
+++ b/scripts/plot_mobility_latency_energy.py
@@ -90,7 +90,7 @@ def plot(
             color=color,
             label=label,
         )
-        ax.set_xlabel("Scenario")
+        ax.set_xlabel("")
         ax.set_xticks(range(len(df["scenario"])))
         ax.set_xticklabels(df["scenario_label"], rotation=45, ha="right")
         ax.set_ylabel(label)

--- a/scripts/plot_mobility_multichannel.py
+++ b/scripts/plot_mobility_multichannel.py
@@ -72,7 +72,7 @@ def plot(
             color=color,
             label=label,
         )
-        ax.set_xlabel("Scenario")
+        ax.set_xlabel("")
         ax.set_xticks(range(len(df)))
         ax.set_xticklabels(
             df["scenario_label"], rotation=45, ha="right"


### PR DESCRIPTION
## Summary
- Remove "Scenario" x-axis label in `plot_mobility_multichannel.py`
- Remove "Scenario" x-axis label in `plot_mobility_latency_energy.py`

## Testing
- `python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv`
- `python scripts/plot_mobility_latency_energy.py results/mobility_latency_energy_agg.csv`
- `grep -R "Scenario" -n figures`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7107d0c2c8331b416ca1ce36f20aa