### PR TITLE
docs: clarify figure abbreviations and mobile fast speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,7 +788,7 @@ python scripts/run_mobility_latency_energy.py --nodes 50 --packets 100 --seed 1
 ```
 
 Le script `run_mobility_multichannel.py` propose notamment le scénario
-`mobile_multi_fast` où les nœuds se déplacent à 10 m/s.
+`mobile_multi_fast`, où les nœuds se déplacent à 10 m/s.
 
 `run_mobility_latency_energy.py` produit `results/mobility_latency_energy.csv`
 que `plot_mobility_latency_energy.py` peut visualiser.
@@ -840,6 +840,14 @@ nodes = 50
 packets = 100
 seed = 1
 ```
+
+### Abréviations des figures
+
+Les légendes des graphiques utilisent les abréviations suivantes :
+
+- `N` : nombre de nœuds.
+- `C` : nombre de canaux.
+- `speed` : vitesse des nœuds en m/s.
 
 ## Limites actuelles
 

--- a/docs/usage_scenarios.md
+++ b/docs/usage_scenarios.md
@@ -10,7 +10,7 @@ sortie attendue.
 
 ### `run_mobility_multichannel.py`
 - **Description** : exécute plusieurs scénarios combinant mobilité et mono/tri‑canal,
-  dont `mobile_multi_fast` où les nœuds se déplacent à 10 m/s.
+  dont `mobile_multi_fast`, où les nœuds se déplacent à 10 m/s.
 - **Paramètres principaux**
   - `--nodes` (50) : nombre de nœuds simulés.
   - `--packets` (100) : paquets à émettre par nœud.
@@ -142,7 +142,15 @@ fournies et les tests de mobilité associés.
 5. `run_battery_tracking.py` : enregistre `results/battery_tracking.csv`.
 6. `plot_battery_tracking.py` : sauvegarde `figures/battery_tracking.png`.
 7. `plot_node_positions.py` : exporte la carte des nœuds
-   (`figures/node_positions.png`).
+    (`figures/node_positions.png`).
+
+### Abréviations des figures
+
+Les légendes des graphiques utilisent les abréviations suivantes :
+
+- `N` : nombre de nœuds.
+- `C` : nombre de canaux.
+- `speed` : vitesse des nœuds en m/s.
 
 ### Génération des tests de mobilité
 

--- a/figures/pdr_vs_scenario.svg
+++ b/figures/pdr_vs_scenario.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2025-09-14T19:09:34.346172</dc:date>
+    <dc:date>2025-09-14T19:20:57.946626</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -43,7 +43,7 @@ L 233.395245 391.348182
 L 233.395245 188.512558 
 L 135.822876 188.512558 
 z
-" clip-path="url(#p06e9317a57)" style="fill: #1f77b4"/>
+" clip-path="url(#pc019723077)" style="fill: #1f77b4"/>
    </g>
    <g id="patch_4">
     <path d="M 257.788337 391.348182 
@@ -51,7 +51,7 @@ L 355.360705 391.348182
 L 355.360705 179.457441 
 L 257.788337 179.457441 
 z
-" clip-path="url(#p06e9317a57)" style="fill: #1f77b4"/>
+" clip-path="url(#pc019723077)" style="fill: #1f77b4"/>
    </g>
    <g id="patch_5">
     <path d="M 379.753798 391.348182 
@@ -59,7 +59,7 @@ L 477.326166 391.348182
 L 477.326166 188.319401 
 L 379.753798 188.319401 
 z
-" clip-path="url(#p06e9317a57)" style="fill: #1f77b4"/>
+" clip-path="url(#pc019723077)" style="fill: #1f77b4"/>
    </g>
    <g id="patch_6">
     <path d="M 501.719258 391.348182 
@@ -67,7 +67,7 @@ L 599.291627 391.348182
 L 599.291627 179.456961 
 L 501.719258 179.456961 
 z
-" clip-path="url(#p06e9317a57)" style="fill: #1f77b4"/>
+" clip-path="url(#pc019723077)" style="fill: #1f77b4"/>
    </g>
    <g id="patch_7">
     <path d="M 623.684719 391.348182 
@@ -75,7 +75,7 @@ L 721.257088 391.348182
 L 721.257088 179.457498 
 L 623.684719 179.457498 
 z
-" clip-path="url(#p06e9317a57)" style="fill: #1f77b4"/>
+" clip-path="url(#pc019723077)" style="fill: #1f77b4"/>
    </g>
    <g id="patch_8">
     <path d="M 745.65018 391.348182 
@@ -83,7 +83,7 @@ L 843.222549 391.348182
 L 843.222549 178.211155 
 L 745.65018 178.211155 
 z
-" clip-path="url(#p06e9317a57)" style="fill: #1f77b4"/>
+" clip-path="url(#pc019723077)" style="fill: #1f77b4"/>
    </g>
    <g id="patch_9">
     <path d="M 867.615641 391.348182 
@@ -91,7 +91,7 @@ L 965.188009 391.348182
 L 965.188009 187.575864 
 L 867.615641 187.575864 
 z
-" clip-path="url(#p06e9317a57)" style="fill: #1f77b4"/>
+" clip-path="url(#pc019723077)" style="fill: #1f77b4"/>
    </g>
    <g id="patch_10">
     <path d="M 989.581102 391.348182 
@@ -99,18 +99,18 @@ L 1087.15347 391.348182
 L 1087.15347 216.157449 
 L 989.581102 216.157449 
 z
-" clip-path="url(#p06e9317a57)" style="fill: #1f77b4"/>
+" clip-path="url(#pc019723077)" style="fill: #1f77b4"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m2f9b33f55c" d="M 0 0 
+       <path id="m72903950cd" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2f9b33f55c" x="184.60906" y="391.348182" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72903950cd" x="184.60906" y="391.348182" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -407,7 +407,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m2f9b33f55c" x="306.574521" y="391.348182" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72903950cd" x="306.574521" y="391.348182" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -474,7 +474,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m2f9b33f55c" x="428.539982" y="391.348182" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72903950cd" x="428.539982" y="391.348182" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -507,7 +507,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m2f9b33f55c" x="550.505443" y="391.348182" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72903950cd" x="550.505443" y="391.348182" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -540,7 +540,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m2f9b33f55c" x="672.470904" y="391.348182" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72903950cd" x="672.470904" y="391.348182" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -574,7 +574,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m2f9b33f55c" x="794.436364" y="391.348182" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72903950cd" x="794.436364" y="391.348182" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -639,7 +639,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m2f9b33f55c" x="916.401825" y="391.348182" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72903950cd" x="916.401825" y="391.348182" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -699,7 +699,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m2f9b33f55c" x="1038.367286" y="391.348182" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72903950cd" x="1038.367286" y="391.348182" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -735,12 +735,12 @@ z
     <g id="ytick_1">
      <g id="line2d_9">
       <defs>
-       <path id="m6ea1dcb854" d="M 0 0 
+       <path id="m9a1abc16ac" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6ea1dcb854" x="88.256346" y="391.348182" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a1abc16ac" x="88.256346" y="391.348182" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -753,7 +753,7 @@ L -3.5 0
     <g id="ytick_2">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m6ea1dcb854" x="88.256346" y="348.630546" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a1abc16ac" x="88.256346" y="348.630546" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -767,7 +767,7 @@ L -3.5 0
     <g id="ytick_3">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m6ea1dcb854" x="88.256346" y="305.912909" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a1abc16ac" x="88.256346" y="305.912909" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -802,7 +802,7 @@ z
     <g id="ytick_4">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m6ea1dcb854" x="88.256346" y="263.195273" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a1abc16ac" x="88.256346" y="263.195273" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -816,7 +816,7 @@ z
     <g id="ytick_5">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m6ea1dcb854" x="88.256346" y="220.477636" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a1abc16ac" x="88.256346" y="220.477636" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -871,7 +871,7 @@ z
     <g id="ytick_6">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m6ea1dcb854" x="88.256346" y="177.76" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a1abc16ac" x="88.256346" y="177.76" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1042,62 +1042,62 @@ z
    <g id="LineCollection_1">
     <path d="M 184.60906 194.964709 
 L 184.60906 182.060407 
-" clip-path="url(#p06e9317a57)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
+" clip-path="url(#pc019723077)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
     <path d="M 306.574521 180.387656 
 L 306.574521 178.527227 
-" clip-path="url(#p06e9317a57)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
+" clip-path="url(#pc019723077)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
     <path d="M 428.539982 194.454841 
 L 428.539982 182.18396 
-" clip-path="url(#p06e9317a57)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
+" clip-path="url(#pc019723077)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
     <path d="M 550.505443 180.401682 
 L 550.505443 178.512241 
-" clip-path="url(#p06e9317a57)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
+" clip-path="url(#pc019723077)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
     <path d="M 672.470904 180.350952 
 L 672.470904 178.564043 
-" clip-path="url(#p06e9317a57)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
+" clip-path="url(#pc019723077)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
     <path d="M 794.436364 178.441555 
 L 794.436364 177.980755 
-" clip-path="url(#p06e9317a57)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
+" clip-path="url(#pc019723077)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
     <path d="M 916.401825 188.783423 
 L 916.401825 186.368304 
-" clip-path="url(#p06e9317a57)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
+" clip-path="url(#pc019723077)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
     <path d="M 1038.367286 219.065469 
 L 1038.367286 213.249428 
-" clip-path="url(#p06e9317a57)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
+" clip-path="url(#pc019723077)" style="fill: none; stroke: #000000; stroke-width: 1.5"/>
    </g>
    <g id="line2d_15">
     <defs>
-     <path id="mbe7b6a1e60" d="M 4 0 
+     <path id="m9831cfdf02" d="M 4 0 
 L -4 -0 
 " style="stroke: #000000"/>
     </defs>
-    <g clip-path="url(#p06e9317a57)">
-     <use xlink:href="#mbe7b6a1e60" x="184.60906" y="194.964709" style="fill: #1f77b4; stroke: #000000"/>
-     <use xlink:href="#mbe7b6a1e60" x="306.574521" y="180.387656" style="fill: #1f77b4; stroke: #000000"/>
-     <use xlink:href="#mbe7b6a1e60" x="428.539982" y="194.454841" style="fill: #1f77b4; stroke: #000000"/>
-     <use xlink:href="#mbe7b6a1e60" x="550.505443" y="180.401682" style="fill: #1f77b4; stroke: #000000"/>
-     <use xlink:href="#mbe7b6a1e60" x="672.470904" y="180.350952" style="fill: #1f77b4; stroke: #000000"/>
-     <use xlink:href="#mbe7b6a1e60" x="794.436364" y="178.441555" style="fill: #1f77b4; stroke: #000000"/>
-     <use xlink:href="#mbe7b6a1e60" x="916.401825" y="188.783423" style="fill: #1f77b4; stroke: #000000"/>
-     <use xlink:href="#mbe7b6a1e60" x="1038.367286" y="219.065469" style="fill: #1f77b4; stroke: #000000"/>
+    <g clip-path="url(#pc019723077)">
+     <use xlink:href="#m9831cfdf02" x="184.60906" y="194.964709" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m9831cfdf02" x="306.574521" y="180.387656" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m9831cfdf02" x="428.539982" y="194.454841" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m9831cfdf02" x="550.505443" y="180.401682" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m9831cfdf02" x="672.470904" y="180.350952" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m9831cfdf02" x="794.436364" y="178.441555" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m9831cfdf02" x="916.401825" y="188.783423" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m9831cfdf02" x="1038.367286" y="219.065469" style="fill: #1f77b4; stroke: #000000"/>
     </g>
    </g>
    <g id="line2d_16">
-    <g clip-path="url(#p06e9317a57)">
-     <use xlink:href="#mbe7b6a1e60" x="184.60906" y="182.060407" style="fill: #1f77b4; stroke: #000000"/>
-     <use xlink:href="#mbe7b6a1e60" x="306.574521" y="178.527227" style="fill: #1f77b4; stroke: #000000"/>
-     <use xlink:href="#mbe7b6a1e60" x="428.539982" y="182.18396" style="fill: #1f77b4; stroke: #000000"/>
-     <use xlink:href="#mbe7b6a1e60" x="550.505443" y="178.512241" style="fill: #1f77b4; stroke: #000000"/>
-     <use xlink:href="#mbe7b6a1e60" x="672.470904" y="178.564043" style="fill: #1f77b4; stroke: #000000"/>
-     <use xlink:href="#mbe7b6a1e60" x="794.436364" y="177.980755" style="fill: #1f77b4; stroke: #000000"/>
-     <use xlink:href="#mbe7b6a1e60" x="916.401825" y="186.368304" style="fill: #1f77b4; stroke: #000000"/>
-     <use xlink:href="#mbe7b6a1e60" x="1038.367286" y="213.249428" style="fill: #1f77b4; stroke: #000000"/>
+    <g clip-path="url(#pc019723077)">
+     <use xlink:href="#m9831cfdf02" x="184.60906" y="182.060407" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m9831cfdf02" x="306.574521" y="178.527227" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m9831cfdf02" x="428.539982" y="182.18396" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m9831cfdf02" x="550.505443" y="178.512241" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m9831cfdf02" x="672.470904" y="178.564043" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m9831cfdf02" x="794.436364" y="177.980755" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m9831cfdf02" x="916.401825" y="186.368304" style="fill: #1f77b4; stroke: #000000"/>
+     <use xlink:href="#m9831cfdf02" x="1038.367286" y="213.249428" style="fill: #1f77b4; stroke: #000000"/>
     </g>
    </g>
    <g id="line2d_17">
     <path d="M 88.256346 177.76 
 L 1134.72 177.76 
-" clip-path="url(#p06e9317a57)" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #808080; stroke-width: 1.5"/>
+" clip-path="url(#pc019723077)" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #808080; stroke-width: 1.5"/>
    </g>
    <g id="patch_11">
     <path d="M 88.256346 391.348182 
@@ -1463,21 +1463,21 @@ z
    </g>
    <g id="legend_1">
     <g id="patch_15">
-     <path d="M 375.825673 207.617954 
-L 847.150673 207.617954 
-Q 850.350673 207.617954 850.350673 204.417954 
-L 850.350673 135.562954 
-Q 850.350673 132.362954 847.150673 132.362954 
-L 375.825673 132.362954 
-Q 372.625673 132.362954 372.625673 135.562954 
-L 372.625673 204.417954 
-Q 372.625673 207.617954 375.825673 207.617954 
+     <path d="M 383.453173 207.617954 
+L 839.523173 207.617954 
+Q 842.723173 207.617954 842.723173 204.417954 
+L 842.723173 135.562954 
+Q 842.723173 132.362954 839.523173 132.362954 
+L 383.453173 132.362954 
+Q 380.253173 132.362954 380.253173 135.562954 
+L 380.253173 204.417954 
+Q 380.253173 207.617954 383.453173 207.617954 
 z
 " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
     <g id="text_25">
-     <!-- N : nombre de nœuds, C : nombre de canaux, speed : m/s -->
-     <g transform="translate(379.025673 150.920454) scale(0.16 -0.16)">
+     <!-- N: nombre de nœuds, C: nombre de canaux, speed: m/s -->
+     <g transform="translate(386.653173 150.920454) scale(0.16 -0.16)">
       <defs>
        <path id="DejaVuSans-3a" d="M 750 794 
 L 1409 794 
@@ -1574,59 +1574,56 @@ z
 " transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#DejaVuSans-4e"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(74.804688 0)"/>
-      <use xlink:href="#DejaVuSans-3a" transform="translate(106.591797 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(140.283203 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(172.070312 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(235.449219 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(296.630859 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(394.042969 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(457.519531 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(496.382812 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(557.90625 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(589.693359 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(653.169922 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(714.693359 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(746.480469 0)"/>
-      <use xlink:href="#DejaVuSans-153" transform="translate(809.859375 0)"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(912.154297 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(975.533203 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(1039.009766 0)"/>
-      <use xlink:href="#DejaVuSans-2c" transform="translate(1091.109375 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1122.896484 0)"/>
-      <use xlink:href="#DejaVuSans-43" transform="translate(1154.683594 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1224.507812 0)"/>
-      <use xlink:href="#DejaVuSans-3a" transform="translate(1256.294922 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1289.986328 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(1321.773438 0)"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(1385.152344 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(1446.333984 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(1543.746094 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(1607.222656 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(1646.085938 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1707.609375 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(1739.396484 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(1802.873047 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1864.396484 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(1896.183594 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(1951.164062 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(2012.443359 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(2075.822266 0)"/>
-      <use xlink:href="#DejaVuSans-75" transform="translate(2137.101562 0)"/>
-      <use xlink:href="#DejaVuSans-78" transform="translate(2200.480469 0)"/>
-      <use xlink:href="#DejaVuSans-2c" transform="translate(2259.660156 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(2291.447266 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(2323.234375 0)"/>
-      <use xlink:href="#DejaVuSans-70" transform="translate(2375.333984 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(2438.810547 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(2500.333984 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(2561.857422 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(2625.333984 0)"/>
-      <use xlink:href="#DejaVuSans-3a" transform="translate(2657.121094 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(2690.8125 0)"/>
-      <use xlink:href="#DejaVuSans-6d" transform="translate(2722.599609 0)"/>
-      <use xlink:href="#DejaVuSans-2f" transform="translate(2820.011719 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(2853.703125 0)"/>
+      <use xlink:href="#DejaVuSans-3a" transform="translate(74.804688 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(108.496094 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(140.283203 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(203.662109 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(264.84375 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(362.255859 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(425.732422 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(464.595703 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(526.119141 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(557.90625 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(621.382812 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(682.90625 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(714.693359 0)"/>
+      <use xlink:href="#DejaVuSans-153" transform="translate(778.072266 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(880.367188 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(943.746094 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1007.222656 0)"/>
+      <use xlink:href="#DejaVuSans-2c" transform="translate(1059.322266 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1091.109375 0)"/>
+      <use xlink:href="#DejaVuSans-43" transform="translate(1122.896484 0)"/>
+      <use xlink:href="#DejaVuSans-3a" transform="translate(1192.720703 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1226.412109 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1258.199219 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1321.578125 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(1382.759766 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(1480.171875 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1543.648438 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1582.511719 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1644.035156 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1675.822266 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1739.298828 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1800.822266 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1832.609375 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1887.589844 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1948.869141 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(2012.248047 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(2073.527344 0)"/>
+      <use xlink:href="#DejaVuSans-78" transform="translate(2136.90625 0)"/>
+      <use xlink:href="#DejaVuSans-2c" transform="translate(2196.085938 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2227.873047 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(2259.660156 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(2311.759766 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2375.236328 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2436.759766 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(2498.283203 0)"/>
+      <use xlink:href="#DejaVuSans-3a" transform="translate(2561.759766 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2595.451172 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(2627.238281 0)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(2724.650391 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(2758.341797 0)"/>
      </g>
     </g>
     <g id="line2d_18">
@@ -1669,7 +1666,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p06e9317a57">
+  <clipPath id="pc019723077">
    <rect x="88.256346" y="177.76" width="1046.463654" height="213.588182"/>
   </clipPath>
  </defs>


### PR DESCRIPTION
## Summary
- document abbreviations used in figures (N, C, speed)
- note that `mobile_multi_fast` uses a speed of 10 m/s
- regenerate PDR vs scenario figure

## Testing
- `python scripts/plot_mobility_latency_energy.py results/mobility_latency_energy.csv`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7153c131c833182305313cfba213b