### PR TITLE
feat: adjust legend position in mobility models plot

### DIFF
--- a/scripts/plot_mobility_models.py
+++ b/scripts/plot_mobility_models.py
@@ -72,7 +72,7 @@ def plot(
 
         ax.set_title(f"{name} by model (0 ≤ {name} ≤ {cap:g} {unit})")
         ax.bar_label(bars, fmt=fmt, label_type="center")
-        ax.legend(loc="upper center", bbox_to_anchor=(0.5, 1.15), ncol=1)
+        ax.legend(loc="upper center", bbox_to_anchor=(0.5, 1.25), ncol=1)
         fig.tight_layout(rect=[0, 0, 1, 0.9])
         for ext in ("png", "jpg", "eps"):
             dpi = 300 if ext in ("png", "jpg") else None


### PR DESCRIPTION
## Summary
- raise legend placement in mobility models plot for clearer visibility

## Testing
- `python scripts/run_mobility_models.py --nodes 5 --packets 5`
- `python scripts/plot_mobility_models.py results/mobility_models.csv -o figures`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7191d6f588331ab804f10aca0997b