### PR TITLE
Enforce minimum replicates for mobility model simulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ avec `--path-map` :
 python scripts/run_mobility_models.py --model path --path-map carte.json
 ```
 
+Le paramètre `--replicates` répète chaque scénario (valeur par défaut : 5).
+Nous recommandons d'exécuter au moins 5 répétitions pour obtenir des
+statistiques fiables.
+
 ## Multi-canaux
 
 LoRaFlexSim permet d'utiliser plusieurs canaux radio. Passez une instance

--- a/scripts/run_mobility_models.py
+++ b/scripts/run_mobility_models.py
@@ -99,7 +99,12 @@ def main() -> None:
     parser.add_argument("--adr-server", action="store_true", help="Enable ADR on server")
     parser.add_argument("--area-size", type=float, default=1000.0, help="Square area size in metres")
     parser.add_argument("--interval", type=float, default=60.0, help="Mean packet interval (s)")
-    parser.add_argument("--replicates", type=int, default=1, help="Number of simulation replicates")
+    parser.add_argument(
+        "--replicates",
+        type=int,
+        default=5,
+        help="Number of simulation replicates (>=5)",
+    )
     parser.add_argument("--path-map", help="Path map file (JSON or CSV) for path mobility")
     parser.add_argument(
         "--model",
@@ -108,6 +113,9 @@ def main() -> None:
         help="Mobility model to simulate (may be repeated). Defaults to all.",
     )
     args = parser.parse_args()
+
+    if args.replicates < 5:
+        parser.error("replicates must be ≥5")
 
     if args.model and "path" in args.model and not args.path_map:
         parser.error("--path-map is required when using the 'path' model")


### PR DESCRIPTION
## Summary
- default to five simulation replicates in `run_mobility_models.py`
- error when fewer than five replicates are requested
- document recommended replicate count in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7233006308331adeaff8e5f00769f