### PR TITLE
Add mobile_single_many_nodes scenario and aggregation test

### DIFF
--- a/scripts/run_mobility_multichannel.py
+++ b/scripts/run_mobility_multichannel.py
@@ -8,6 +8,7 @@ scenarios (``static_single``, ``static_multi``, ``mobile_single`` and
 * ``mobile_multi_fast`` – mobile nodes moving at 10 m/s
 * ``mobile_multi_many_channels`` – mobile nodes operating on six channels
 * ``static_multi_many_nodes`` – static nodes with 200 devices
+* ``mobile_single_many_nodes`` – mobile nodes with 200 devices
 
 The number of nodes, packet interval, mobility speed and number of channels can
 be customised for each scenario via command-line options.  Every scenario may be
@@ -165,6 +166,11 @@ def main() -> None:
         },
         "static_single_many_nodes": {
             "mobility": False,
+            "channels": 1,
+            "nodes": 200,
+        },
+        "mobile_single_many_nodes": {
+            "mobility": True,
             "channels": 1,
             "nodes": 200,
         },

--- a/tests/test_run_mobility_multichannel_script.py
+++ b/tests/test_run_mobility_multichannel_script.py
@@ -67,6 +67,11 @@ def test_run_mobility_multichannel_script(tmp_path, monkeypatch):
     }
     assert expected_cols.issubset(df.columns)
 
+    row = df[df["scenario"] == "mobile_single_many_nodes"].iloc[0]
+    assert row["nodes"] == 200
+    assert row["channels"] == 1
+    assert row["pdr_mean"] == 80.0
+
     csv_path.unlink()
 
     # Restore stubbed modules and paths


### PR DESCRIPTION
## Summary
- extend mobility multichannel runner with `mobile_single_many_nodes` scenario
- document new scenario
- verify aggregation captures nodes and channels for new scenario

## Testing
- `pytest tests/test_run_mobility_multichannel_script.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7245799248331a307229571ccdffc