### PR TITLE
Adjust legend placement in plotting scripts

### DIFF
--- a/scripts/plot_battery_tracking.py
+++ b/scripts/plot_battery_tracking.py
@@ -92,8 +92,8 @@ def main() -> None:
     ax.set_title("Temporal evolution of residual battery energy")
     ax.set_ylim(0, 100)
     ax.grid(True)
-    ax.legend(loc="upper center", bbox_to_anchor=(0.5, 1.3), ncol=1)
-    fig.tight_layout(rect=[0, 0, 1, 0.9])
+    ax.legend(loc="upper center", bbox_to_anchor=(0.5, 1.4), ncol=1)
+    fig.tight_layout(rect=[0, 0, 1, 0.85])
 
     os.makedirs(FIGURES_DIR, exist_ok=True)
     base = os.path.join(FIGURES_DIR, "battery_tracking")

--- a/scripts/plot_mobility_latency_energy.py
+++ b/scripts/plot_mobility_latency_energy.py
@@ -117,11 +117,11 @@ def plot(
         ax.bar_label(bars, fmt=fmt, label_type="center")
         ax.legend(
             loc="upper center",
-            bbox_to_anchor=(0.5, 1.3),
+            bbox_to_anchor=(0.5, 1.4),
             ncol=1,
             title="N: number of nodes, C: number of channels, speed: m/s",
         )
-        fig.tight_layout(rect=[0, 0, 1, 0.9])
+        fig.tight_layout(rect=[0, 0, 1, 0.85])
         stem = Path(filename).stem
         for ext in ("png", "jpg", "eps", "svg"):
             dpi = 300 if ext in ("png", "jpg") else None

--- a/scripts/plot_mobility_models.py
+++ b/scripts/plot_mobility_models.py
@@ -72,8 +72,8 @@ def plot(
 
         ax.set_title(f"{name} by model (0 ≤ {name} ≤ {cap:g} {unit})")
         ax.bar_label(bars, fmt=fmt, label_type="center")
-        ax.legend(loc="upper center", bbox_to_anchor=(0.5, 1.3), ncol=1)
-        fig.tight_layout(rect=[0, 0, 1, 0.9])
+        ax.legend(loc="upper center", bbox_to_anchor=(0.5, 1.4), ncol=1)
+        fig.tight_layout(rect=[0, 0, 1, 0.85])
         for ext in ("png", "jpg", "eps"):
             dpi = 300 if ext in ("png", "jpg") else None
             fig.savefig(out_dir / f"{metric}_vs_model.{ext}", dpi=dpi)

--- a/scripts/plot_mobility_multichannel.py
+++ b/scripts/plot_mobility_multichannel.py
@@ -100,11 +100,11 @@ def plot(
         ax.bar_label(bars, fmt=fmt, label_type="center")
         ax.legend(
             loc="upper center",
-            bbox_to_anchor=(0.5, 1.3),
+            bbox_to_anchor=(0.5, 1.4),
             ncol=1,
             title="N: number of nodes, C: number of channels, speed: m/s",
         )
-        fig.tight_layout(rect=[0, 0, 1, 0.9])
+        fig.tight_layout(rect=[0, 0, 1, 0.85])
         for ext in ("png", "jpg", "eps", "svg"):
             dpi = 300 if ext in ("png", "jpg") else None
             fig.savefig(out_dir / f"{metric}_vs_scenario.{ext}", dpi=dpi)

--- a/scripts/plot_sf_vs_scenario.py
+++ b/scripts/plot_sf_vs_scenario.py
@@ -58,8 +58,8 @@ def plot(csv_path: str, output_dir: str = "figures", by_model: bool = False) -> 
     ax.set_ylabel("Average SF")
     ax.set_title("Average SF by " + ("model" if by_model else "scenario"))
     ax.bar_label(bars, fmt="%.2f", label_type="center")
-    ax.legend(loc="upper center", bbox_to_anchor=(0.5, 1.3), ncol=3)
-    fig.tight_layout(rect=[0, 0, 1, 0.9])
+    ax.legend(loc="upper center", bbox_to_anchor=(0.5, 1.4), ncol=3)
+    fig.tight_layout(rect=[0, 0, 1, 0.85])
 
     stem = "avg_sf_vs_model" if by_model else "avg_sf_vs_scenario"
     for ext in ("png", "jpg", "eps"):


### PR DESCRIPTION
## Summary
- Raise legend anchors above axes in plotting utilities to prevent overlap
- Expand top margins so legends remain within figure boundaries

## Testing
- `python scripts/plot_mobility_models.py results/mobility_models.csv`
- `python scripts/plot_sf_vs_scenario.py /tmp/mle.csv`
- `python scripts/plot_mobility_latency_energy.py /tmp/mle.csv`
- `python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv`
- `python scripts/plot_battery_tracking.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c742aba29c8331abf5405d9ab6f9ce