### PR TITLE
Translate figure text and docs to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,47 +679,46 @@ nodes,gateways,channels,mode,interval,steps,delivered,collisions,PDR(%),energy,a
 * **avg_delay** : délai moyen des paquets livrés.
 * **throughput_bps** : débit binaire moyen des paquets délivrés.
 
-## Exemple d'analyse
+## Analysis example
 
-Un script Python d'exemple nommé `analyse_resultats.py` est disponible dans le
-dossier `examples`. Il agrège plusieurs fichiers CSV et trace le PDR en fonction
-du nombre de nœuds :
-
-```bash
-python examples/analyse_resultats.py resultats1.csv resultats2.csv
-```
-
-Le script affiche le PDR moyen puis sauvegarde un graphique `pdr_par_nodes`
-en PNG, JPG et EPS.
-
-Si le même fichier CSV contient plusieurs runs produits avec le dashboard ou
-`run.py --runs`, le script `analyse_runs.py` permet d'obtenir les moyennes par
-run :
+An example Python script named `analyse_resultats.py` is available in the
+`examples` folder. It aggregates several CSV files and plots PDR against the
+number of nodes:
 
 ```bash
-python examples/analyse_runs.py résultats.csv
+python examples/analyse_resultats.py results1.csv results2.csv
 ```
 
-Deux autres utilitaires exploitent les fichiers `metrics_*.csv` exportés par le
-tableau de bord :
+The script prints the average PDR and saves a `pdr_by_nodes` figure
+as PNG, JPG and EPS.
+
+If the same CSV file contains multiple runs produced with the dashboard or
+`run.py --runs`, the `analyse_runs.py` script computes the mean per run:
+
+```bash
+python examples/analyse_runs.py results.csv
+```
+
+Two other utilities work with the `metrics_*.csv` files exported by the
+dashboard:
 
 ```bash
 python examples/plot_sf_distribution.py metrics1.csv metrics2.csv
-python examples/plot_energy.py metrics.csv            # énergie totale
-python examples/plot_energy.py --per-node metrics.csv # par nœud
+python examples/plot_energy.py metrics.csv            # total energy
+python examples/plot_energy.py --per-node metrics.csv # per node
 python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv
 python scripts/plot_mobility_latency_energy.py results/mobility_latency_energy.csv
 ```
 
-`plot_sf_distribution.py` génère `sf_distribution` en PNG, JPG et EPS alors
-que `plot_energy.py` crée `energy_total` ou `energy_per_node` dans ces
-formats.
-`plot_mobility_multichannel.py` enregistre `pdr_vs_scenario.png`,
-`collision_rate_vs_scenario.png` et `avg_energy_per_node_vs_scenario.png`
-dans le dossier `figures/`.
-`plot_mobility_latency_energy.py` crée `pdr_vs_scenario.svg`,
-`avg_delay_vs_scenario.svg` et `avg_energy_per_node_vs_scenario.svg` au
-format vectoriel.
+`plot_sf_distribution.py` generates `sf_distribution` in PNG, JPG and EPS,
+while `plot_energy.py` creates `energy_total` or `energy_per_node` in the
+same formats.
+`plot_mobility_multichannel.py` saves `pdr_vs_scenario.png`,
+`collision_rate_vs_scenario.png` and `avg_energy_per_node_vs_scenario.png`
+in the `figures/` folder.
+`plot_mobility_latency_energy.py` creates `pdr_vs_scenario.svg`,
+`avg_delay_vs_scenario.svg` and `avg_energy_per_node_vs_scenario.svg` as
+vector graphics.
 
 ## Calcul de l'airtime
 

--- a/examples/analyse_resultats.py
+++ b/examples/analyse_resultats.py
@@ -11,34 +11,34 @@ def main(files: list[str], output_dir: Path, basename: str) -> None:
     by_nodes = df.groupby("nodes")["PDR(%)"].mean()
     print(by_nodes)
     by_nodes.plot(marker="o")
-    plt.xlabel("Nombre de nœuds")
-    plt.ylabel("PDR moyen (%)")
+    plt.xlabel("Number of nodes")
+    plt.ylabel("Average PDR (%)")
     plt.grid(True)
     plt.tight_layout()
     output_dir.mkdir(parents=True, exist_ok=True)
     for ext, params in {"png": {"dpi": 300}, "jpg": {"dpi": 300}, "eps": {}}.items():
         path = output_dir / f"{basename}.{ext}"
         plt.savefig(path, **params)
-        print(f"Graphique sauvegardé dans {path}")
+        print(f"Figure saved to {path}")
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Analyse des résultats et sauvegarde le PDR moyen en PNG, JPG et EPS"
+            "Analyze results and save the mean PDR as PNG, JPG and EPS"
         )
     )
-    parser.add_argument("files", nargs="+", help="Fichiers de résultats CSV")
+    parser.add_argument("files", nargs="+", help="Result CSV files")
     parser.add_argument(
         "--output-dir",
         type=Path,
         default=Path("."),
-        help="Répertoire de sortie (défaut : dossier courant)",
+        help="Output directory (default: current folder)",
     )
     parser.add_argument(
         "--basename",
-        default="pdr_par_nodes",
-        help="Nom de base du fichier sans extension",
+        default="pdr_by_nodes",
+        help="Base filename without extension",
     )
     return parser.parse_args(argv)
 

--- a/examples/plot_energy.py
+++ b/examples/plot_energy.py
@@ -1,4 +1,4 @@
-"""Trace la consommation d'énergie totale ou par nœud depuis des CSV."""
+"""Plot total or per-node energy consumption from CSV files."""
 import sys
 import argparse
 from pathlib import Path
@@ -17,31 +17,31 @@ def main(
     if per_node:
         cols = [c for c in df.columns if c.startswith("energy_by_node.")]
         if not cols:
-            print("Aucune colonne de consommation par nœud trouvée.")
+            print("No per-node consumption columns found.")
             return
         energy = {int(c.split(".")[1]): df[c].mean() for c in cols}
         nodes = sorted(energy)
         values = [energy[n] for n in nodes]
         plt.bar(nodes, values)
-        plt.xlabel("Nœud")
-        plt.ylabel("Énergie consommée (J)")
+        plt.xlabel("Node")
+        plt.ylabel("Energy consumed (J)")
         plt.grid(True)
         if basename is None:
             basename = "energy_per_node"
     else:
         col = "energy_J" if "energy_J" in df.columns else "energy"
         if col not in df.columns:
-            print("Aucune colonne energy_J ou energy trouvée.")
+            print("No energy_J or energy column found.")
             return
         if "nodes" in df.columns:
             series = df.groupby("nodes")[col].mean()
             series.plot(marker="o")
-            plt.xlabel("Nombre de nœuds")
+            plt.xlabel("Number of nodes")
         else:
             series = df[col]
             series.plot(marker="o")
-            plt.xlabel("Exécution")
-        plt.ylabel("Énergie consommée (J)")
+            plt.xlabel("Run")
+        plt.ylabel("Energy consumed (J)")
         plt.grid(True)
         if basename is None:
             basename = "energy_total"
@@ -49,32 +49,31 @@ def main(
     for ext, params in {"png": {"dpi": 300}, "jpg": {"dpi": 300}, "eps": {}}.items():
         path = output_dir / f"{basename}.{ext}"
         plt.savefig(path, **params)
-        print(f"Graphique sauvegardé dans {path}")
+        print(f"Figure saved to {path}")
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Trace l'énergie consommée et sauvegarde le graphique en PNG, JPG et EPS"
+        description="Plot energy consumption and save the figure as PNG, JPG and EPS",
     )
-    parser.add_argument("files", nargs="+", help="Fichiers metrics CSV")
+    parser.add_argument("files", nargs="+", help="Metrics CSV files")
     parser.add_argument(
         "--per-node",
         action="store_true",
-        help="Trace la consommation pour chaque nœud",
+        help="Plot consumption per node",
     )
     parser.add_argument(
         "--output-dir",
         type=Path,
         default=Path("."),
-        help="Répertoire de sortie (défaut : dossier courant)",
+        help="Output directory (default: current folder)",
     )
     parser.add_argument(
         "--basename",
         default=None,
-        help="Nom de base du fichier sans extension. Par défaut 'energy_total' ou 'energy_per_node' selon --per-node",
+        help="Base filename without extension. Defaults to 'energy_total' or 'energy_per_node' depending on --per-node",
     )
     return parser.parse_args(argv)
-
 
 if __name__ == "__main__":
     args = parse_args(sys.argv[1:])

--- a/examples/plot_sf_distribution.py
+++ b/examples/plot_sf_distribution.py
@@ -1,4 +1,4 @@
-"""Trace la distribution des Spreading Factors depuis des fichiers CSV."""
+"""Plot the distribution of Spreading Factors from CSV files."""
 import sys
 import argparse
 from pathlib import Path
@@ -15,7 +15,7 @@ def main(files: list[str], output_dir: Path, basename: str) -> None:
         sf_cols = [c for c in df.columns if c.startswith("sf")]
         sf_counts = {int(c[2:]): int(df[c].sum()) for c in sf_cols}
     if not sf_counts:
-        print("Aucune colonne SF trouvée dans les fichiers fournis.")
+        print("No SF column found in provided files.")
         return
     sfs = sorted(sf_counts)
     counts = [sf_counts[sf] for sf in sfs]
@@ -23,31 +23,31 @@ def main(files: list[str], output_dir: Path, basename: str) -> None:
         print(f"SF{sf}: {count}")
     plt.bar(sfs, counts)
     plt.xlabel("Spreading Factor")
-    plt.ylabel("Paquets")
+    plt.ylabel("Packets")
     plt.grid(True)
     plt.tight_layout()
     output_dir.mkdir(parents=True, exist_ok=True)
     for ext, params in {"png": {"dpi": 300}, "jpg": {"dpi": 300}, "eps": {}}.items():
         path = output_dir / f"{basename}.{ext}"
         plt.savefig(path, **params)
-        print(f"Graphique sauvegardé dans {path}")
+        print(f"Figure saved to {path}")
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Trace la distribution des SF et sauvegarde en PNG, JPG et EPS"
+        description="Plot SF distribution and save as PNG, JPG and EPS",
     )
-    parser.add_argument("files", nargs="+", help="Fichiers metrics CSV")
+    parser.add_argument("files", nargs="+", help="Metrics CSV files")
     parser.add_argument(
         "--output-dir",
         type=Path,
         default=Path("."),
-        help="Répertoire de sortie (défaut : dossier courant)",
+        help="Output directory (default: current folder)",
     )
     parser.add_argument(
         "--basename",
         default="sf_distribution",
-        help="Nom de base du fichier sans extension",
+        help="Base filename without extension",
     )
     return parser.parse_args(argv)
 


### PR DESCRIPTION
## Summary
- replace French axis labels and console messages with English equivalents across example plotting scripts
- translate README snippet on analysis utilities to English

## Testing
- `python examples/analyse_resultats.py tmp_output/results1.csv tmp_output/results2.csv --output-dir tmp_output`
- `python examples/plot_energy.py tmp_output/metrics.csv --output-dir tmp_output`
- `python examples/plot_energy.py --per-node tmp_output/metrics.csv --output-dir tmp_output`
- `python examples/plot_sf_distribution.py tmp_output/metrics_sf.csv --output-dir tmp_output`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7458fee0c83319902d4acbca46411