### PR TITLE
Improve legend spacing in mobility multichannel plots

### DIFF
--- a/scripts/plot_mobility_multichannel.py
+++ b/scripts/plot_mobility_multichannel.py
@@ -100,11 +100,11 @@ def plot(
         ax.bar_label(bars, fmt=fmt, label_type="center")
         ax.legend(
             loc="upper center",
-            bbox_to_anchor=(0.5, 1.4),
+            bbox_to_anchor=(0.5, 1.6),
             ncol=1,
             title="N: number of nodes, C: number of channels, speed: m/s",
         )
-        fig.tight_layout(rect=[0, 0, 1, 0.85])
+        fig.tight_layout(rect=[0, 0, 1, 0.7])
         for ext in ("png", "jpg", "eps", "svg"):
             dpi = 300 if ext in ("png", "jpg") else None
             fig.savefig(out_dir / f"{metric}_vs_scenario.{ext}", dpi=dpi)


### PR DESCRIPTION
## Summary
- raise legend anchoring and tighten layout for mobility multichannel plots to improve legend separation from title

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7b5d0e4b48331a949cec8fe3775c7