### PR TITLE
Allow configurable plot formats and set opaque legend

### DIFF
--- a/scripts/plot_mobility_multichannel.py
+++ b/scripts/plot_mobility_multichannel.py
@@ -20,6 +20,7 @@ def plot(
     output_dir: str = "figures",
     max_delay: float | None = None,
     max_energy: float | None = None,
+    formats: tuple[str, ...] = ("png", "jpg", "svg"),
 ) -> None:
     df = pd.read_csv(csv_path)
     if hasattr(plt, "rcParams"):
@@ -108,8 +109,9 @@ def plot(
             ncol=1,
             title="N: number of nodes, C: number of channels, speed: m/s",
             framealpha=1.0,
+            facecolor="white",
         )
-        for ext in ("png", "jpg", "eps", "svg"):
+        for ext in formats:
             dpi = 300 if ext in ("png", "jpg") else None
             fig.savefig(out_dir / f"{metric}_vs_scenario.{ext}", dpi=dpi)
         plt.close(fig)
@@ -136,8 +138,14 @@ def main(argv: list[str] | None = None) -> None:
         default=None,
         help="Y-axis maximum for energy plots",
     )
+    parser.add_argument(
+        "--formats",
+        nargs="+",
+        default=("png", "jpg", "svg"),
+        help="File formats for output figures",
+    )
     args = parser.parse_args(argv)
-    plot(args.csv, args.output_dir, args.max_delay, args.max_energy)
+    plot(args.csv, args.output_dir, args.max_delay, args.max_energy, tuple(args.formats))
 
 
 if __name__ == "__main__":

--- a/tests/test_plot_mobility_multichannel.py
+++ b/tests/test_plot_mobility_multichannel.py
@@ -121,8 +121,8 @@ def test_plot(tmp_path, monkeypatch):
     csv_path = Path('tests/data/mobility_multichannel_summary.csv')
     plot_module.plot(str(csv_path), tmp_path)
 
-    for ext in ('png', 'jpg', 'eps'):
-        assert (tmp_path / f'pdr_vs_scenario.{ext}').is_file()
+    for ext in ("png", "jpg", "svg"):
+        assert (tmp_path / f"pdr_vs_scenario.{ext}").is_file()
     # The x-axis should list every tested node/channel combination once.
     labels = [tick.get_text() for tick in captured['ax'].get_xticklabels()]
     unique_labels = list(dict.fromkeys(labels))


### PR DESCRIPTION
## Summary
- prevent transparency warning by setting legend framealpha to 1.0 and white background
- allow users to choose output formats for mobility multichannel plots (defaults to png, jpg, svg)
- adjust tests for new default formats

## Testing
- `python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv -o /tmp/test_plots --formats eps`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c800049c7c833182614a76c68e5876