### PR TITLE
Add EPS support to mobility multichannel plots

### DIFF
--- a/scripts/generate_all_figures.py
+++ b/scripts/generate_all_figures.py
@@ -85,6 +85,11 @@ def main() -> None:
             python,
             str(SCRIPT_DIR / "plot_mobility_multichannel.py"),
             str(RESULTS_DIR / "mobility_multichannel.csv"),
+            "--formats",
+            "png",
+            "jpg",
+            "svg",
+            "eps",
         ],
         check=True,
     )

--- a/scripts/plot_mobility_multichannel.py
+++ b/scripts/plot_mobility_multichannel.py
@@ -20,7 +20,7 @@ def plot(
     output_dir: str = "figures",
     max_delay: float | None = None,
     max_energy: float | None = None,
-    formats: tuple[str, ...] = ("png", "jpg", "svg"),
+    formats: tuple[str, ...] = ("png", "jpg", "svg", "eps"),
 ) -> None:
     df = pd.read_csv(csv_path)
     if hasattr(plt, "rcParams"):
@@ -112,8 +112,12 @@ def plot(
             facecolor="white",
         )
         for ext in formats:
-            dpi = 300 if ext in ("png", "jpg") else None
-            fig.savefig(out_dir / f"{metric}_vs_scenario.{ext}", dpi=dpi)
+            fig.savefig(
+                out_dir / f"{metric}_vs_scenario.{ext}",
+                dpi=300,
+                bbox_inches="tight",
+                pad_inches=0,
+            )
         plt.close(fig)
 
 
@@ -141,7 +145,7 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument(
         "--formats",
         nargs="+",
-        default=("png", "jpg", "svg"),
+        default=("png", "jpg", "svg", "eps"),
         help="File formats for output figures",
     )
     args = parser.parse_args(argv)

--- a/tests/test_plot_mobility_multichannel.py
+++ b/tests/test_plot_mobility_multichannel.py
@@ -102,7 +102,7 @@ def test_plot(tmp_path, monkeypatch):
 
     plot_module = importlib.import_module('scripts.plot_mobility_multichannel')
 
-    def fake_savefig(self, filename, dpi=None):
+    def fake_savefig(self, filename, dpi=None, **kwargs):
         Path(filename).touch()
 
     monkeypatch.setattr(figure_module.Figure, 'savefig', fake_savefig)
@@ -121,7 +121,7 @@ def test_plot(tmp_path, monkeypatch):
     csv_path = Path('tests/data/mobility_multichannel_summary.csv')
     plot_module.plot(str(csv_path), tmp_path)
 
-    for ext in ("png", "jpg", "svg"):
+    for ext in ("png", "jpg", "svg", "eps"):
         assert (tmp_path / f"pdr_vs_scenario.{ext}").is_file()
     # The x-axis should list every tested node/channel combination once.
     labels = [tick.get_text() for tick in captured['ax'].get_xticklabels()]


### PR DESCRIPTION
## Summary
- Save mobility multichannel figures in EPS in addition to PNG/JPG/SVG
- Run generate_all_figures with explicit EPS output
- Test plot_mobility_multichannel to confirm EPS files are created

## Testing
- `pytest tests/test_plot_mobility_multichannel.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c806a42ffc83318774f79814ca71bb