### PR TITLE
Add selectable node/channel pairs for mobility plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,7 @@ python examples/plot_sf_distribution.py metrics1.csv metrics2.csv
 python examples/plot_energy.py metrics.csv            # total energy
 python examples/plot_energy.py --per-node metrics.csv # per node
 python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv
+python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv --allowed 50,1 200,3
 python scripts/plot_mobility_latency_energy.py results/mobility_latency_energy.csv
 ```
 
@@ -715,7 +716,8 @@ while `plot_energy.py` creates `energy_total` or `energy_per_node` in the
 same formats.
 `plot_mobility_multichannel.py` saves `pdr_vs_scenario.png`,
 `collision_rate_vs_scenario.png` and `avg_energy_per_node_vs_scenario.png`
-in the `figures/` folder.
+in the `figures/` folder. Use `--allowed N,C ...` to limit the plot to
+specific node/channel pairs.
 `plot_mobility_latency_energy.py` creates `pdr_vs_scenario.svg`,
 `avg_delay_vs_scenario.svg` and `avg_energy_per_node_vs_scenario.svg` as
 vector graphics.

--- a/docs/usage_scenarios.md
+++ b/docs/usage_scenarios.md
@@ -41,7 +41,8 @@ sortie attendue.
 ## Scripts de visualisation (`plot_*`)
 
 ### `plot_mobility_multichannel.py`
-- **Paramètres** : chemin du CSV agrégé et `--output-dir` ("figures").
+- **Paramètres** : chemin du CSV agrégé, `--output-dir` ("figures") et optionnel
+  `--allowed N,C` pour limiter les couples nœuds/canaux.
 - **Sortie** : graphiques PNG de PDR, taux de collision, délai moyen et énergie
   moyenne par nœud.
 
@@ -76,6 +77,7 @@ Les scénarios utilisés par les scripts `run_mobility_multichannel.py` et
 ```bash
 python scripts/run_mobility_multichannel.py --nodes 200 --interval 1 --replicates 5
 python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv
+python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv --allowed 50,1 200,3
 ```
 
 Le premier script génère `results/mobility_multichannel.csv`, puis le second
@@ -133,8 +135,8 @@ fournies et les tests de mobilité associés.
 
 1. `run_mobility_multichannel.py` : génère
    `results/mobility_multichannel.csv`.
-2. `plot_mobility_multichannel.py <csv>` : crée des PNG (PDR, collisions,
-   délai moyen, énergie par nœud).
+2. `plot_mobility_multichannel.py <csv> [--allowed N,C ...]` : crée des PNG
+   (PDR, collisions, délai moyen, énergie par nœud).
 3. `run_mobility_latency_energy.py` : produit
    `results/mobility_latency_energy.csv`.
 4. `plot_mobility_latency_energy.py <csv>` : génère des SVG (PDR, délai,


### PR DESCRIPTION
## Summary
- allow specifying node/channel pairs for `plot_mobility_multichannel.py` via new `--allowed` option
- document and test plotting all or selected `(nodes, channels)` combinations

## Testing
- `pytest tests/test_plot_mobility_multichannel.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c808c0fb88833185757694165bce59