### PR TITLE
Add mobile_multi_many_nodes scenario to mobility script

### DIFF
--- a/scripts/run_mobility_multichannel.py
+++ b/scripts/run_mobility_multichannel.py
@@ -7,6 +7,7 @@ scenarios (``static_single``, ``static_multi``, ``mobile_single`` and
 
 * ``mobile_multi_fast`` – mobile nodes moving at 10 m/s
 * ``mobile_multi_many_channels`` – mobile nodes operating on six channels
+* ``mobile_multi_many_nodes`` – mobile nodes with 200 devices and multiple channels
 * ``static_multi_many_nodes`` – static nodes with 200 devices
 * ``mobile_single_many_nodes`` – mobile nodes with 200 devices
 
@@ -159,6 +160,11 @@ def main() -> None:
         "mobile_multi": {"mobility": True, "channels": args.channels},
         "mobile_multi_fast": {"mobility": True, "channels": args.channels, "speed": 10.0},
         "mobile_multi_many_channels": {"mobility": True, "channels": 6},
+        "mobile_multi_many_nodes": {
+            "mobility": True,
+            "channels": args.channels,
+            "nodes": 200,
+        },
         "static_multi_many_nodes": {
             "mobility": False,
             "channels": args.channels,


### PR DESCRIPTION
## Summary
- add `mobile_multi_many_nodes` scenario to `run_mobility_multichannel.py`
- document new scenario in script description

## Testing
- `pytest`
- `python scripts/run_mobility_multichannel.py --nodes 50 --channels 3 --packets 1`

------
https://chatgpt.com/codex/tasks/task_e_68c810c5ffb48331bfc842601873db8b