### PR TITLE
Add scenario filter option to mobility multichannel plotting script

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,6 +708,7 @@ python examples/plot_energy.py metrics.csv            # total energy
 python examples/plot_energy.py --per-node metrics.csv # per node
 python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv
 python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv --allowed 50,1 200,3
+python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv --scenarios static_single mobile_single
 python scripts/plot_mobility_latency_energy.py results/mobility_latency_energy.csv
 ```
 
@@ -717,7 +718,8 @@ same formats.
 `plot_mobility_multichannel.py` saves `pdr_vs_scenario.png`,
 `collision_rate_vs_scenario.png` and `avg_energy_per_node_vs_scenario.png`
 in the `figures/` folder. Use `--allowed N,C ...` to limit the plot to
-specific node/channel pairs.
+specific node/channel pairs and `--scenarios NAME ...` to select particular
+scenarios.
 `plot_mobility_latency_energy.py` creates `pdr_vs_scenario.svg`,
 `avg_delay_vs_scenario.svg` and `avg_energy_per_node_vs_scenario.svg` as
 vector graphics.

--- a/docs/usage_scenarios.md
+++ b/docs/usage_scenarios.md
@@ -41,8 +41,9 @@ sortie attendue.
 ## Scripts de visualisation (`plot_*`)
 
 ### `plot_mobility_multichannel.py`
-- **Paramètres** : chemin du CSV agrégé, `--output-dir` ("figures") et optionnel
-  `--allowed N,C` pour limiter les couples nœuds/canaux.
+- **Paramètres** : chemin du CSV agrégé, `--output-dir` ("figures") et options
+  `--allowed N,C` pour limiter les couples nœuds/canaux, `--scenarios nom` pour
+  filtrer les scénarios.
 - **Sortie** : graphiques PNG de PDR, taux de collision, délai moyen et énergie
   moyenne par nœud.
 
@@ -78,6 +79,7 @@ Les scénarios utilisés par les scripts `run_mobility_multichannel.py` et
 python scripts/run_mobility_multichannel.py --nodes 200 --interval 1 --replicates 5
 python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv
 python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv --allowed 50,1 200,3
+python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv --scenarios static_single mobile_single
 ```
 
 Le premier script génère `results/mobility_multichannel.csv`, puis le second

--- a/scripts/plot_mobility_multichannel.py
+++ b/scripts/plot_mobility_multichannel.py
@@ -6,6 +6,8 @@ Usage::
     python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv
     python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv \
         --allowed 50,1 200,3
+    python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv \
+        --scenarios static_single mobile_single
 """
 
 from __future__ import annotations
@@ -24,6 +26,7 @@ def plot(
     max_energy: float | None = None,
     formats: tuple[str, ...] = ("png", "jpg", "svg", "eps"),
     allowed: set[tuple[int, int]] | None = None,
+    scenarios: set[str] | None = None,
 ) -> None:
     df = pd.read_csv(csv_path)
     if hasattr(plt, "rcParams"):
@@ -31,6 +34,9 @@ def plot(
 
     if "scenario" not in df.columns:
         raise ValueError("CSV must contain a 'scenario' column")
+
+    if scenarios is not None:
+        df = df[df["scenario"].isin(scenarios)]
 
     out_dir = Path(output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -157,6 +163,13 @@ def main(argv: list[str] | None = None) -> None:
         default=None,
         help="Allowed node-channel pairs (e.g. 50,1 200,3); show all if omitted",
     )
+    parser.add_argument(
+        "--scenarios",
+        nargs="+",
+        metavar="NAME",
+        default=None,
+        help="Scenario names to include (e.g. static_single mobile_single); show all if omitted",
+    )
     args = parser.parse_args(argv)
     allowed = None
     if args.allowed is not None:
@@ -176,6 +189,7 @@ def main(argv: list[str] | None = None) -> None:
         args.max_energy,
         tuple(args.formats),
         allowed,
+        set(args.scenarios) if args.scenarios is not None else None,
     )
 
 

--- a/tests/test_plot_mobility_multichannel.py
+++ b/tests/test_plot_mobility_multichannel.py
@@ -148,6 +148,18 @@ def test_plot(tmp_path, monkeypatch):
     ]
     assert unique_labels == expected_allowed
 
+    # Filtering by scenario names should select those scenarios.
+    scenarios = ['static_single', 'mobile_single']
+    plot_module.plot(str(csv_path), tmp_path, scenarios=set(scenarios))
+    labels = [tick.get_text() for tick in captured['ax'].get_xticklabels()]
+    unique_labels = list(dict.fromkeys(labels))
+    df_scen = df[df['scenario'].isin(scenarios)][['nodes', 'channels']].drop_duplicates()
+    expected_scenarios = [
+        f'N={int(n)}, C={int(c)}'
+        for n, c in df_scen.to_numpy()
+    ]
+    assert unique_labels == expected_scenarios
+
     legend = captured['ax'].get_legend()
     if legend is not None:
         title = legend.get_title().get_text()


### PR DESCRIPTION
## Summary
- allow selecting specific scenarios in plot_mobility_multichannel.py with new `--scenarios` argument
- document the new flag in script help, README, and usage docs
- extend tests to cover scenario filtering behavior

## Testing
- `python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv --scenarios static_single mobile_single`
- `pytest tests/test_plot_mobility_multichannel.py`

------
https://chatgpt.com/codex/tasks/task_e_68c8144b61d4833194ffee359ca8299c