### PR TITLE
Remove plot titles and extra legend entries

### DIFF
--- a/scripts/plot_mobility_latency_energy.py
+++ b/scripts/plot_mobility_latency_energy.py
@@ -99,7 +99,7 @@ def plot(
         if metric == "pdr":
             cap = 100.0
             ax.set_ylim(0, cap)
-            ax.axhline(cap, linestyle="--", color="grey", label="100 %")
+            ax.axhline(cap, linestyle="--", color="grey")
         elif metric == "avg_delay":
             cap = max_delay or df[mean_col].max() * 1.1
             ax.set_ylim(0, cap)
@@ -110,10 +110,6 @@ def plot(
             cap = df[mean_col].max() * 1.1
             ax.set_ylim(0, cap)
 
-        title = f"{name} by scenario (0 ≤ {name} ≤ {cap:g} {unit})"
-        if param_text:
-            title += f"\n{param_text}"
-        ax.set_title(title)
         ax.bar_label(bars, fmt=fmt, label_type="center")
         ax.legend(
             loc="upper center",

--- a/scripts/plot_mobility_models.py
+++ b/scripts/plot_mobility_models.py
@@ -59,7 +59,7 @@ def plot(
         if metric == "pdr":
             cap = 100.0
             ax.set_ylim(0, cap)
-            ax.axhline(cap, linestyle="--", color="grey", label="100 %")
+            ax.axhline(cap, linestyle="--", color="grey")
         elif metric == "avg_delay":
             cap = max_delay or df[mean_col].max() * 1.1
             ax.set_ylim(0, cap)
@@ -70,7 +70,6 @@ def plot(
             cap = df[mean_col].max() * 1.1
             ax.set_ylim(0, cap)
 
-        ax.set_title(f"{name} by model (0 ≤ {name} ≤ {cap:g} {unit})")
         ax.bar_label(bars, fmt=fmt, label_type="center")
         ax.legend(loc="upper center", bbox_to_anchor=(0.5, 1.4), ncol=1)
         fig.tight_layout(rect=[0, 0, 1, 0.85])


### PR DESCRIPTION
## Summary
- strip hard-coded titles from mobility plots to declutter output
- remove "100 %" reference line labels from PDR plots so legends show only bar series

## Testing
- `pytest`
- `python scripts/plot_mobility_latency_energy.py /tmp/mobility_latency_energy_plot.csv -o figures/mobility_latency_energy`
- `python scripts/plot_mobility_models.py /tmp/mobility_models_plot.csv -o figures/mobility_models`


------
https://chatgpt.com/codex/tasks/task_e_68c82c9f2108833196eb9dde53a84ed9