### PR TITLE
Preserve explicit energy profiles

### DIFF
--- a/loraflexsim/launcher/gateway.py
+++ b/loraflexsim/launcher/gateway.py
@@ -53,7 +53,9 @@ class Gateway:
 
             self.profile = get_profile(energy_profile)
         else:
-            self.profile = energy_profile or DEFAULT_ENERGY_PROFILE
+            self.profile = (
+                DEFAULT_ENERGY_PROFILE if energy_profile is None else energy_profile
+            )
         self.energy_consumed = 0.0
         self.energy_tx = 0.0
         self.energy_rx = 0.0

--- a/loraflexsim/launcher/node.py
+++ b/loraflexsim/launcher/node.py
@@ -119,7 +119,9 @@ class Node:
 
             self.profile = get_profile(energy_profile)
         else:
-            self.profile = energy_profile or DEFAULT_ENERGY_PROFILE
+            self.profile = (
+                DEFAULT_ENERGY_PROFILE if energy_profile is None else energy_profile
+            )
 
         # Énergie et compteurs de paquets
         self.energy_consumed = 0.0

--- a/tests/test_energy_profile_preservation.py
+++ b/tests/test_energy_profile_preservation.py
@@ -1,0 +1,18 @@
+from loraflexsim.launcher.energy_profiles import EnergyProfile
+from loraflexsim.launcher.node import Node
+from loraflexsim.launcher.gateway import Gateway
+
+
+class FalseyProfile(EnergyProfile):
+    def __bool__(self):
+        return False
+
+
+def test_falsey_profile_preserved():
+    profile = FalseyProfile()
+
+    node = Node(0, 0.0, 0.0, 7, 14, energy_profile=profile)
+    assert node.profile is profile
+
+    gw = Gateway(0, 0.0, 0.0, energy_profile=profile)
+    assert gw.profile is profile


### PR DESCRIPTION
## Summary
- Avoid overriding provided energy profiles in Node and Gateway when the profile object evaluates to falsey
- Add regression test ensuring falsey profiles are preserved

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c8307d2fd08331b4070769266e726b