### PR TITLE
Ensure noiseless channels always deliver packets

### DIFF
--- a/docs/lorawan_features.md
+++ b/docs/lorawan_features.md
@@ -31,6 +31,9 @@ Ce document résume les différences entre la simulation FLoRa d'origine
   deux cas.
 - Un mécanisme d’ADR est disponible de part et d’autre, bien que
   l’algorithme diffère légèrement.
+- Les conditions de réception (uplink comme downlink) reproduisent
+  désormais exactement celles de FLoRa, sans suppression aléatoire
+  supplémentaire.
 
 ## Fonctionnalités propres à la version Python
 

--- a/loraflexsim/launcher/simulator.py
+++ b/loraflexsim/launcher/simulator.py
@@ -880,8 +880,6 @@ class Simulator:
                 if not self.pure_poisson_mode:
                     if rssi < node.channel.detection_threshold_dBm:
                         continue  # trop faible pour être détecté
-                    if random.random() < 0.3:
-                        continue  # paquet ignoré aléatoirement
                     snr_threshold = (
                         node.channel.sensitivity_dBm.get(sf, -float("inf"))
                         - node.channel.noise_floor_dBm()
@@ -1205,9 +1203,6 @@ class Simulator:
                     if rssi < node.channel.detection_threshold_dBm:
                         node.downlink_pending = max(0, node.downlink_pending - 1)
                         continue
-                    if random.random() < 0.3:
-                        node.downlink_pending = max(0, node.downlink_pending - 1)
-                        continue
                     snr_threshold = (
                         node.channel.sensitivity_dBm.get(node.sf, -float("inf"))
                         - node.channel.noise_floor_dBm()
@@ -1345,9 +1340,6 @@ class Simulator:
                 )
                 if not self.pure_poisson_mode:
                     if rssi < node.channel.detection_threshold_dBm:
-                        node.downlink_pending = max(0, node.downlink_pending - 1)
-                        continue
-                    if random.random() < 0.3:
                         node.downlink_pending = max(0, node.downlink_pending - 1)
                         continue
                     snr_threshold = (

--- a/tests/test_no_random_drop.py
+++ b/tests/test_no_random_drop.py
@@ -1,0 +1,105 @@
+"""Integration tests ensuring a noiseless channel delivers every packet."""
+
+from loraflexsim.launcher.channel import Channel
+from loraflexsim.launcher.simulator import EventType, Simulator
+
+
+def make_clean_channel() -> Channel:
+    """Return a channel without any random impairments."""
+
+    return Channel(
+        shadowing_std=0.0,
+        fast_fading_std=0.0,
+        time_variation_std=0.0,
+        variable_noise_std=0.0,
+        noise_floor_std=0.0,
+        multipath_taps=1,
+        impulsive_noise_prob=0.0,
+        impulsive_noise_dB=0.0,
+        phase_noise_std_dB=0.0,
+        clock_jitter_std_s=0.0,
+        pa_ramp_up_s=0.0,
+        pa_ramp_down_s=0.0,
+        fine_fading_std=0.0,
+    )
+
+
+def test_clean_channel_uplink_delivery():
+    channel = make_clean_channel()
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        area_size=1.0,
+        transmission_mode="Periodic",
+        packet_interval=1.0,
+        packets_to_send=5,
+        mobility=False,
+        channels=[channel],
+        fixed_sf=7,
+        fixed_tx_power=14,
+        seed=123,
+    )
+
+    sim.run()
+    node = sim.nodes[0]
+
+    assert node.tx_attempted == 5
+    assert node.rx_delivered == node.tx_attempted
+    assert sim.packets_lost_collision == 0
+    assert sim.packets_lost_no_signal == 0
+
+
+def test_clean_channel_rx_window_downlink_delivery():
+    channel = make_clean_channel()
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        area_size=1.0,
+        transmission_mode="Periodic",
+        packet_interval=1.0,
+        packets_to_send=1,
+        mobility=False,
+        channels=[channel],
+        fixed_sf=7,
+        fixed_tx_power=14,
+        seed=321,
+    )
+
+    node = sim.nodes[0]
+    downlink_scheduled = False
+
+    while sim.event_queue:
+        next_event = sim.event_queue[0]
+        if not downlink_scheduled and next_event.type == EventType.RX_WINDOW:
+            sim.network_server.send_downlink(node, b"ping")
+            downlink_scheduled = True
+        sim.step()
+
+    assert downlink_scheduled
+    assert node.downlink_pending == 0
+    assert node.fcnt_down == 1
+
+
+def test_clean_channel_class_c_downlink_delivery():
+    channel = make_clean_channel()
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        area_size=1.0,
+        transmission_mode="Periodic",
+        packet_interval=1.0,
+        packets_to_send=1,
+        mobility=False,
+        channels=[channel],
+        node_class="C",
+        fixed_sf=7,
+        fixed_tx_power=14,
+        seed=999,
+    )
+
+    node = sim.nodes[0]
+    sim.network_server.send_downlink(node, b"hello")
+    sim.run()
+
+    assert node.downlink_pending == 0
+    assert node.fcnt_down == 1


### PR DESCRIPTION
## Summary
- remove the non-deterministic 30% drop applied to uplinks and downlinks outside of pure Poisson mode
- add integration tests covering noiseless uplink, class A downlink, and class C continuous reception
- document that the simulator’s reception logic now mirrors FLoRa without extra random drops

## Testing
- pytest tests/test_no_random_drop.py

------
https://chatgpt.com/codex/tasks/task_e_68cabe4a49648331852ad2d70b5598f7