### PR TITLE
Update channel documentation and validation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,10 @@ scénarios FLoRa. Voici la liste complète des options :
 
 - `num_nodes` : nombre de nœuds à créer lorsque aucun fichier INI n'est fourni.
 - `num_gateways` : nombre de passerelles générées automatiquement.
-- `area_size` : dimension (m) du carré dans lequel sont placés nœuds et
-  passerelles.
+- `area_size` : longueur du côté (m) du carré dans lequel sont placés nœuds et
+  passerelles. Pour estimer rapidement la surface couverte : `area_size = 1000`
+  représente `1 km²`, `area_size = 2000` correspond à `4 km²` et `area_size =
+  5000` couvre `25 km²`.
 - `transmission_mode` : `Random` (émissions Poisson) ou `Periodic`.
 - `packet_interval` : moyenne ou période fixe entre transmissions (s).
   La valeur par défaut est `100` s.

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -55,3 +55,18 @@ pytest loraflexsim/tests/test_flora_trace_alignment.py
 All tolerances default to ±0.6 dB. They can be relaxed for investigations by
 setting the `FLORA_TRACE_TOLERANCE` environment variable before running
 `pytest`, for example `FLORA_TRACE_TOLERANCE=1.0 pytest ...`.
+
+## Validation FLoRa
+
+The latest channel fixes are covered by dedicated tests to ensure the Python
+implementation stays aligned with the FLoRa reference:
+
+- `tests/test_channel_path_loss.py` checks that the `flora` preset reproduces
+  the log-normal path-loss curve of the OMNeT++ module for multiple distances
+  without numerical drift【F:tests/test_channel_path_loss.py†L1-L31】.
+- `tests/test_channel_path_loss_validation.py` rejects non-positive distances
+  for the Hata-Okumura and Oulu models, mirroring the constraints enforced in
+  FLoRa【F:tests/test_channel_path_loss_validation.py†L1-L15】.
+
+Both tests currently pass with `pytest`, confirming the regression coverage of
+the FLoRa alignment.

--- a/docs/equations_flora.md
+++ b/docs/equations_flora.md
@@ -44,12 +44,24 @@ loss = B + 10 * n * log10(distance / d0) - antenna_gain
 ```
 
 Les paramètres par défaut sont `B = 128.95` dB, `n = 2.32`, `d0 = 1000` m et
-`antenna_gain = 0` dBi【F:loraflexsim/launcher/channel.py†L26-L42】. Pour une
+`antenna_gain = 0` dBi【F:loraflexsim/launcher/channel.py†L26-L41】. Pour une
 distance de `2` km :
 
 ```text
 loss = 128.95 + 23.2 * log10(2) ≈ 135.9 dB
 ```
+
+Ces variantes rejettent désormais explicitement les distances nulles ou
+négatives en levant une `ValueError`, ce qui évite des entrées non physiques et
+aligne les validations sur celles de FLoRa【F:loraflexsim/launcher/channel.py†L12-L41】【F:tests/test_channel_path_loss_validation.py†L1-L15】.
+
+### Obstacles avec le PHY OMNeT++
+
+Lorsque `Channel` utilise le PHY inspiré d'OMNeT++, le calcul `compute_rssi`
+appelle d'abord `OmnetPHY` puis retranche l'atténuation supplémentaire fournie
+par `ObstacleLoss` si les positions sont connues. Les obstacles sont donc pris
+en compte quel que soit le modèle de PHY actif, y compris avec les optimisations
+`omnet_phy` introduites pour reproduire le comportement FLoRa【F:loraflexsim/launcher/channel.py†L579-L616】.
 
 ## Taux d'erreur paquet (PER)
 

--- a/docs/lorawan_features.md
+++ b/docs/lorawan_features.md
@@ -34,6 +34,10 @@ Ce document résume les différences entre la simulation FLoRa d'origine
 - Les conditions de réception (uplink comme downlink) reproduisent
   désormais exactement celles de FLoRa, sans suppression aléatoire
   supplémentaire.
+- Les modèles de canal appliquent les mêmes courbes de perte, rejettent les
+  distances non physiques et tiennent compte des obstacles même avec le PHY
+  OMNeT++, des comportements vérifiés par les tests de validation
+  dédiés【F:loraflexsim/launcher/channel.py†L12-L41】【F:loraflexsim/launcher/channel.py†L579-L616】【F:tests/test_channel_path_loss.py†L1-L31】【F:tests/test_channel_path_loss_validation.py†L1-L15】.
 
 ## Fonctionnalités propres à la version Python
 


### PR DESCRIPTION
## Summary
- clarify in the README that `area_size` corresponds to the side length of the deployment square and provide quick km² conversions
- document the Channel fixes in the FLoRa equations guide, including distance validation and obstacle handling with the OMNeT++ PHY
- note the equivalence of the updated channel behaviour in the LoRaWAN feature comparison and add a FLoRa validation section describing the new regression tests

## Testing
- `pytest tests/test_channel_path_loss.py tests/test_channel_path_loss_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68cacd07fd90833194cf1c7c19167553