### PR TITLE
Add rural long range preset and validation scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,8 @@ réception :
  `(freq, bw, dB)` appliqués au calcul du bruit. Chaque entrée définit
  un niveau de bruit spécifique pour la bande concernée.
 - `environment` : preset rapide pour le modèle de propagation
-  (`urban`, `urban_dense`, `suburban`, `rural`, `indoor` ou `flora`).
+  (`urban`, `urban_dense`, `suburban`, `rural`, `rural_long_range`, `indoor`,
+  `flora`, `flora_hata` ou `flora_oulu`).
 - `phy_model` : "omnet", `"omnet_full"`, "flora", "flora_full" ou `"flora_cpp"` pour utiliser un modèle physique avancé reprenant les formules de FLoRa. Le mode `omnet_full` applique directement les équations du `LoRaAnalogModel` d'OMNeT++ avec bruit variable, sélectivité de canal et une gestion précise des collisions partielles. Le mode `flora_cpp` charge la bibliothèque C++ compilée depuis FLoRa pour une précision accrue.
 - `use_flora_curves` : applique directement les équations FLoRa pour la
   puissance reçue et le taux d'erreur.
@@ -310,6 +311,23 @@ canal = Channel(environment="urban")
 
 Ces valeurs influencent le calcul du RSSI et du SNR retournés par
 `Channel.compute_rssi`.
+
+Le preset `rural_long_range` a été ajouté pour couvrir les scénarios LoRaWAN où
+les capteurs se situent à 10–15 km des passerelles. Il abaisse l'exposant de
+perte à `γ = 1.7` et allonge la distance de référence à 100 m afin de maintenir
+le RSSI proche des seuils FLoRa (−130…−120 dBm) tout en conservant une marge de
+sécurité pour le SF12.【F:loraflexsim/launcher/channel.py†L69-L78】  Le tableau
+ci-dessous indique les RSSI attendus pour une puissance d'émission de 14 dBm,
+calculés sans shadowing pour illustrer la tendance de ce preset.
+
+| Distance (km) | RSSI `rural_long_range` (dBm) |
+|---------------|-------------------------------|
+| 1             | −108.0                        |
+| 5             | −119.9                        |
+| 10            | −125.0                        |
+| 12            | −126.4                        |
+| 15            | −128.0                        |
+
 Un module **`propagation_models.py`** regroupe désormais plusieurs modèles :
 `LogDistanceShadowing` pour la perte de parcours classique, `multipath_fading_db`
 pour générer un fading Rayleigh, et la nouvelle classe `CompletePropagation`

--- a/docs/equations_flora.md
+++ b/docs/equations_flora.md
@@ -55,6 +55,29 @@ Ces variantes rejettent désormais explicitement les distances nulles ou
 négatives en levant une `ValueError`, ce qui évite des entrées non physiques et
 aligne les validations sur celles de FLoRa【F:loraflexsim/launcher/channel.py†L12-L41】【F:tests/test_channel_path_loss_validation.py†L1-L15】.
 
+### Profil rural longue portée
+
+Afin de couvrir des scénarios LoRaWAN au-delà de 5 km tout en conservant une
+réception proche des seuils de FLoRa, LoRaFlexSim fournit le preset
+``rural_long_range``. Celui-ci fixe ``γ = 1.7``, ``PATH_LOSS_D0 = 105`` dB et
+``REFERENCE_DISTANCE = 100`` m, avec un shadowing réduit à 1.5 dB pour refléter
+des zones ouvertes à antennes renforcées【F:loraflexsim/launcher/channel.py†L69-L78】.
+Le tableau suivant illustre les RSSI obtenus avec une puissance d'émission de
+14 dBm (cas FLoRa classique) et la marge restante vis-à-vis du seuil SF12
+``-137`` dBm fourni par ``Channel.FLORA_SENSITIVITY``【F:loraflexsim/launcher/channel.py†L52-L65】 :
+
+| Distance (km) | RSSI (dBm) | Marge vs seuil SF12 (dB) |
+|---------------|------------|--------------------------|
+| 1             | −108.0     | 29.0                     |
+| 5             | −119.9     | 17.1                     |
+| 10            | −125.0     | 12.0                     |
+| 12            | −126.4     | 10.6                     |
+| 15            | −128.0     | 9.0                      |
+
+Ces valeurs montrent que, autour de 10–15 km, le RSSI reste dans la fenêtre
+``−130…−120`` dBm suggérée par FLoRa, offrant une marge confortable pour des
+spreading factors élevés tout en conservant une modélisation réaliste.【F:loraflexsim/launcher/channel.py†L69-L78】
+
 ### Obstacles avec le PHY OMNeT++
 
 Lorsque `Channel` utilise le PHY inspiré d'OMNeT++, le calcul `compute_rssi`

--- a/loraflexsim/launcher/channel.py
+++ b/loraflexsim/launcher/channel.py
@@ -69,6 +69,7 @@ class Channel:
         "urban": (2.08, 3.57, 127.41, 40.0),
         "suburban": (2.32, 7.08, 128.95, 1000.0),
         "rural": (2.0, 2.0, 113.0, 1.0),
+        "rural_long_range": (1.7, 1.5, 105.0, 100.0),
         # Parameters matching the FLoRa log-normal shadowing model
         "flora": (2.08, 3.57, 127.41, 40.0),
         "flora_oulu": (2.32, 7.08, 128.95, 1000.0),
@@ -294,7 +295,8 @@ class Channel:
         :param adjacent_interference_dB: Pénalité appliquée aux brouilleurs sur
             un canal adjacent (dB).
         :param environment: Chaîne optionnelle pour charger un preset
-            ("urban", "suburban" ou "rural").
+            ("urban", "suburban", "rural", "rural_long_range", "flora",
+            "flora_hata" ou "flora_oulu").
         :param region: Nom d'un plan de fréquences prédéfini ("EU868", "US915",
             etc.). S'il est fourni, ``frequency_hz`` est ignoré et remplacé par
             la fréquence correspondante du canal ``channel_index``.

--- a/tests/test_channel_path_loss.py
+++ b/tests/test_channel_path_loss.py
@@ -29,3 +29,20 @@ def test_flora_path_loss_matches_flora_reference(distance: float) -> None:
     expected = pl_d0 + 10 * gamma * math.log10(distance / d0)
 
     assert loss == pytest.approx(expected, rel=1e-12, abs=1e-9)
+
+
+def test_rural_long_range_rssi_alignment() -> None:
+    """Le preset longue portée vise les seuils FLoRa entre 10 et 15 km."""
+
+    channel = Channel(environment="rural_long_range")
+    channel.shadowing_std = 0.0
+    target_ranges = {
+        5000.0: (-121.0, -118.0),
+        10000.0: (-128.0, -122.0),
+        15000.0: (-131.0, -123.0),
+    }
+    for distance, (low, high) in target_ranges.items():
+        rssi, _ = channel.compute_rssi(14.0, distance, sf=12)
+        expected = 14.0 - channel.path_loss(distance)
+        assert rssi == pytest.approx(expected, abs=1e-6)
+        assert low <= rssi <= high

--- a/tests/test_long_range_presets.py
+++ b/tests/test_long_range_presets.py
@@ -1,0 +1,72 @@
+"""Validation longue portée des presets FLoRa."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterator
+
+import pytest
+
+from loraflexsim.launcher import Channel, Simulator
+
+
+def _iter_presets() -> Iterator[str]:
+    yield from ("flora", "flora_hata", "flora_oulu")
+
+
+def _make_channel(environment: str) -> Channel:
+    loss_model = "lognorm"
+    if environment == "flora_hata":
+        loss_model = "hata"
+    elif environment == "flora_oulu":
+        loss_model = "oulu"
+    channel = Channel(environment=environment, flora_loss_model=loss_model)
+    # Supprimer le shadowing pour stabiliser le scénario de validation.
+    channel.shadowing_std = 0.0
+    return channel
+
+
+@pytest.fixture(scope="module")
+def long_range_validation() -> tuple[dict[str, float], float]:
+    """Exécute un scénario > 5 km et renvoie les PDR mesurés."""
+
+    metrics: dict[str, float] = {}
+    max_distance = 0.0
+    for env in _iter_presets():
+        channel = _make_channel(env)
+        simulator = Simulator(
+            num_nodes=30,
+            num_gateways=1,
+            area_size=8000.0,
+            packets_to_send=2,
+            transmission_mode="Periodic",
+            packet_interval=600.0,
+            fixed_sf=12,
+            fixed_tx_power=14.0,
+            mobility=False,
+            seed=123,
+            flora_mode=True,
+            channels=[channel],
+        )
+        simulator.run()
+        metrics[env] = simulator.get_metrics()["PDR"]
+        gateway = simulator.gateways[0]
+        farthest = max(
+            math.hypot(node.x - gateway.x, node.y - gateway.y)
+            for node in simulator.nodes
+        )
+        max_distance = max(max_distance, farthest)
+    return metrics, max_distance
+
+
+def test_long_range_presets_pdr(long_range_validation: tuple[dict[str, float], float]) -> None:
+    """Les presets FLoRa restent utilisables au-delà de 5 km."""
+
+    metrics, max_distance = long_range_validation
+    assert max_distance > 5000.0
+    assert set(metrics) == {"flora", "flora_hata", "flora_oulu"}
+    for env, pdr in metrics.items():
+        assert 0.0 <= pdr <= 1.0, env
+    assert metrics["flora_oulu"] >= metrics["flora_hata"]
+    assert metrics["flora_oulu"] > metrics["flora"]
+    assert metrics["flora_hata"] >= metrics["flora"]


### PR DESCRIPTION
## Summary
- add a rural_long_range channel preset tuned for long-distance deployments
- create a >5 km validation test that sweeps the flora*, flora_hata and flora_oulu presets and records PDR
- document the new preset with distance/RSSI guidance in the README and equations reference

## Testing
- pytest tests/test_channel_path_loss.py tests/test_long_range_presets.py

------
https://chatgpt.com/codex/tasks/task_e_68cadb452e388331a18a56547605e254