### PR TITLE
Propagate per-gateway SNIR to ADR and align multi-GW validation

### DIFF
--- a/docs/adr_protocols.md
+++ b/docs/adr_protocols.md
@@ -23,6 +23,11 @@ Lorsque ce SNR offre une marge suffisante, l'algorithme réduit d'abord le
 spreading factor puis la puissance d'émission afin d'augmenter le débit tout en
 restant compatible avec LoRaWAN.
 
+Dans LoRaFlexSim, la mesure utilisée correspond désormais au **SNIR remonté par
+la passerelle** ayant décodé l'uplink. Le serveur conserve un historique par
+passerelle, ce qui reproduit fidèlement le comportement de FLoRa dans les
+déploiements multi-gateways.
+
 **Avantages**
 
 - Optimise le débit et la consommation énergétique.

--- a/docs/tickets/TICKET-002.md
+++ b/docs/tickets/TICKET-002.md
@@ -10,3 +10,8 @@ Avec plusieurs passerelles ou des environnements hétérogènes (bruits différe
 - Propager le SNIR calculé par la passerelle (`Gateway.end_reception`) au lieu de recalculer un SNR global côté serveur.
 - Stocker l’écart type du bruit par passerelle pour rapprocher l’algorithme de `NetworkServerApp::evaluateADR`.
 - Ajouter un test de non-régression comparant l’ADR LoRaFlexSim et FLoRa sur un scénario multi-passerelle.
+
+## Résolution
+- La passerelle transmet désormais le SNIR effectivement calculé lors des collisions et le serveur le programme avec `schedule_receive`.
+- `NetworkServer.receive` mémorise le SNIR par passerelle et l’intègre directement dans `node.snr_history`, ce qui aligne les décisions ADR `max`, `avg` et `adr-max` sur celles de FLoRa.
+- Le test d’intégration `test_multi_gateway_adr_alignment_matches_flora` vérifie que le SNIR moyen restitué par chaque passerelle dans le scénario multi-GW correspond aux traces FLoRa.

--- a/loraflexsim/launcher/node.py
+++ b/loraflexsim/launcher/node.py
@@ -228,6 +228,7 @@ class Node:
         self.history: list[dict] = []
         self.rssi_history: list[float] = []
         self.snr_history: list[float] = []
+        self.gateway_snr_history: dict[int, list[float]] = {}
         self.in_transmission: bool = False
         self.current_end_time: float | None = None
         self.last_airtime: float = 0.0

--- a/loraflexsim/launcher/simulator.py
+++ b/loraflexsim/launcher/simulator.py
@@ -1033,6 +1033,11 @@ class Simulator:
                 if delivered
                 else None
             )
+            if delivered:
+                if event_id in self.network_server.event_rssi:
+                    entry["rssi_dBm"] = self.network_server.event_rssi[event_id]
+                if event_id in self.network_server.event_snir:
+                    entry["snr_dB"] = self.network_server.event_snir[event_id]
 
             if self.debug_rx:
                 if delivered:


### PR DESCRIPTION
## Summary
- propagate the SNIR computed by gateways through `schedule_receive` so the network server records per-gateway link quality
- rework server ADR logic and simulator logging to use the forwarded SNIR while keeping existing aggregation methods intact
- extend the validation matrix with a multi-gateway ADR alignment check and document the new behaviour

## Testing
- `pytest loraflexsim/launcher/tests/test_adr_max.py`
- `pytest tests/integration/test_validation_matrix.py::test_multi_gateway_adr_alignment_matches_flora` *(skipped: pandas not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68caf9ae0a448331b7a6e95d6bdc8626