### PR TITLE
Stabilize noise sampling across simulator operations

### DIFF
--- a/docs/equations_flora.md
+++ b/docs/equations_flora.md
@@ -101,6 +101,13 @@ snr = rssi - noise + snr_offset_dB
 ```
 
 où `noise` provient soit de la table FLoRa, soit du bruit thermique simulé.
+La valeur tirée est désormais mémorisée dans `Channel.last_noise_dBm` et
+réutilisée tout au long du traitement d'une transmission : atténuation par
+interférence, comparaison au seuil de sensibilité et capture par la passerelle
+partagent exactement le même échantillon de bruit. Cette mémorisation évite de
+ré-échantillonner `noise_floor_dBm()` lorsque `noise_floor_std` est non nul et
+stabilise ainsi les décisions « heard »/« collision » du simulateur
+évènementiel.【F:loraflexsim/launcher/simulator.py†L900-L936】【F:loraflexsim/launcher/channel.py†L467-L557】
 Par défaut, aucun « gain de traitement » n'est ajouté afin de reproduire les
 traces SNR issues de FLoRa. Un paramètre optionnel `processing_gain=True`
 permet toutefois de retrouver l'ancien comportement en ajoutant

--- a/loraflexsim/launcher/tests/test_noise_consistency.py
+++ b/loraflexsim/launcher/tests/test_noise_consistency.py
@@ -1,0 +1,68 @@
+from types import MethodType
+
+from loraflexsim.launcher.channel import Channel
+from loraflexsim.launcher.simulator import EventType, Simulator
+
+
+def test_noise_sample_reuse_keeps_heard_and_collision_stable():
+    channel = Channel(noise_floor_std=5.0, phy_model="")
+
+    noise_values = iter([-120.0, -118.0, -140.0])
+    used_noise: list[float] = []
+
+    def fake_noise(self, freq_offset_hz: float = 0.0):
+        try:
+            value = next(noise_values)
+        except StopIteration as exc:  # pragma: no cover - unexpected path
+            raise AssertionError("noise_floor_dBm sampled too many times") from exc
+        used_noise.append(value)
+        self.last_noise_dBm = value
+        return value
+
+    snr_margin = -4.0
+
+    def fake_compute(self, tx_power_dBm, distance, sf, **kwargs):
+        noise = self.noise_floor_dBm(kwargs.get("freq_offset_hz", 0.0))
+        rssi = noise + snr_margin
+        self.last_rssi_dBm = rssi
+        self.last_filter_att_dB = 0.0
+        self.last_freq_hz = self.frequency_hz
+        return rssi, snr_margin
+
+    channel.noise_floor_dBm = MethodType(fake_noise, channel)
+    channel.compute_rssi = MethodType(fake_compute, channel)
+
+    sim = Simulator(
+        num_nodes=2,
+        num_gateways=1,
+        area_size=1.0,
+        transmission_mode="Periodic",
+        packet_interval=1.0,
+        packets_to_send=1,
+        mobility=False,
+        channels=[channel],
+        seed=123,
+    )
+
+    for node in sim.nodes:
+        node.sf = 7
+        node.tx_power = 14.0
+        node.channel = channel
+    threshold = Channel.flora_detection_threshold(7, channel.bandwidth) + channel.sensitivity_margin_dB
+    channel.detection_threshold_dBm = threshold
+
+    sim.event_queue = []
+    sim.event_id_counter = 0
+    for node in sim.nodes:
+        eid = sim.event_id_counter
+        sim.event_id_counter += 1
+        sim._push_event(0.0, EventType.TX_START, eid, node.id)
+
+    sim.run()
+
+    assert used_noise == [-120.0, -118.0]
+    assert len(sim.events_log) == 2
+    assert all(entry["heard"] for entry in sim.events_log)
+    assert {entry["result"] for entry in sim.events_log} == {"CollisionLoss"}
+    assert sim.packets_lost_collision == 2
+    assert sim.packets_lost_no_signal == 0


### PR DESCRIPTION
## Summary
- reuse the sampled noise when adjusting SNR and capture handling, avoiding extra draws in the simulator
- propagate the memorised noise to downlink checks and document the updated behaviour
- add a regression test that confirms heard/collision decisions stay stable with a non-zero noise floor variance

## Testing
- pytest loraflexsim/launcher/tests/test_noise_consistency.py

------
https://chatgpt.com/codex/tasks/task_e_68cb2aa915d4833186628afde968e0b2