### PR TITLE
Fix SNR tracking for validation scenarios

### DIFF
--- a/loraflexsim/launcher/channel.py
+++ b/loraflexsim/launcher/channel.py
@@ -702,6 +702,12 @@ class Channel:
             noise = self._omnet_noise_dBm(sf, freq_offset_hz)
         else:
             noise = self.noise_floor_dBm(freq_offset_hz)
+        # Store the effective noise floor so that downstream components (e.g.
+        # capture logic or server metrics) reuse the same value.  Without this
+        # update the attribute stayed at its default ``0.0`` whenever the
+        # OMNeT++/FLoRa helpers were used, leading to grossly underestimated
+        # SNRs in the validation matrix.
+        self.last_noise_dBm = noise
         snr = rssi - noise + self.snr_offset_dB
         penalty = self._alignment_penalty_db(freq_offset_hz, sync_offset_s, sf)
         snr -= penalty


### PR DESCRIPTION
## Summary
- persist the noise floor used by the PHY so SNR samples remain accurate during validation comparisons
- record the refreshed validation matrix results with all scenarios matching their FLoRa references

## Testing
- pytest tests/integration/test_validation_matrix.py
- python scripts/run_validation.py --output results/validation_matrix.csv

------
https://chatgpt.com/codex/tasks/task_e_68cb304af26483319b4421c89c729898