### PR TITLE
Align flora_cpp SNR with FLoRa noise table

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ fournies dans l'INI de FLoRa.
    python run.py --nodes 5 --mode Periodic --interval 10
    python run.py --long-range-demo            # scénario longue portée (flora_hata)
    python run.py --long-range-demo flora --output long_range.csv
+   python run.py --long-range-demo rural_long_range --seed 3
    ```
     Ajoutez l'option `--seed` pour reproduire exactement le placement des nœuds
     et l'ordre statistique des intervalles.
@@ -584,6 +585,25 @@ le canal avec `phy_model="omnet_full"` ou `"omnet"` et laissez
 Pour le mode OMNeT++, le taux d'erreur binaire est déterminé grâce à la
 fonction `calculateBER` de `LoRaModulation` transposée telle quelle en
 Python afin de reproduire fidèlement les performances de décodage.
+
+### Débogage du bruit/SNR
+
+Les modèles `flora_full` et `flora_cpp` s'appuient désormais sur la table de
+bruit issue de `LoRaAnalogModel.cc`. Cela garantit que le SNR retourné par
+`Channel.compute_rssi` reste identique entre l'implémentation Python et la
+bibliothèque native. Pour inspecter une divergence de SNR :
+
+- vérifiez la valeur de `channel.last_noise_dBm`, mise à jour à chaque appel
+  à `compute_rssi` ;
+- forcez `processing_gain=True` si vous souhaitez retrouver le calcul
+  historique `rssi - bruit + 10·log10(2**sf)` ;
+- assurez-vous que le preset CLI sélectionné (ex. `--long-range-demo`) active
+  bien les courbes FLoRa (`use_flora_curves=True`) lorsque vous comparez les
+  résultats aux traces d'OMNeT++.
+
+Les tests `tests/test_flora_cpp.py` et
+`tests/test_flora_equivalence.py` peuvent être exécutés isolément afin de
+vérifier la cohérence entre les deux implémentations.
 
 Le paramètre ``flora_loss_model`` permet de choisir parmi plusieurs modèles
 d'atténuation : ``"lognorm"`` (par défaut), ``"oulu"`` correspondant à

--- a/loraflexsim/launcher/channel.py
+++ b/loraflexsim/launcher/channel.py
@@ -696,7 +696,10 @@ class Channel:
         attenuation = self._filter_attenuation_db(freq_offset_hz)
         rssi -= attenuation
 
-        if self.phy_model == "flora_full" and sf is not None:
+        if sf is not None and (
+            self.phy_model in ("flora_full", "flora_cpp")
+            or self.use_flora_curves
+        ):
             noise = self._flora_noise_dBm(sf)
         elif self.phy_model == "omnet_full" and sf is not None:
             noise = self._omnet_noise_dBm(sf, freq_offset_hz)

--- a/tests/test_flora_cpp.py
+++ b/tests/test_flora_cpp.py
@@ -16,7 +16,7 @@ def test_rssi_snr_match_python_impl():
     rssi_py, snr_py = ch_py.compute_rssi(14.0, 100.0, sf=7)
     # Derive SNR using the FLoRa noise table to mimic the C++ implementation
     noise_cpp = ch_cpp._flora_noise_dBm(7)
-    snr_cpp = rssi_cpp - noise_cpp + ch_cpp.snr_offset_dB + 10 * math.log10(2 ** 7)
+    snr_cpp = rssi_cpp - noise_cpp + ch_cpp.snr_offset_dB
 
     assert abs(rssi_cpp - rssi_py) <= 0.01
     assert abs(snr_cpp - snr_py) <= 0.01

--- a/tests/test_flora_equivalence.py
+++ b/tests/test_flora_equivalence.py
@@ -36,8 +36,8 @@ def test_flora_equivalence(distance, sf, bandwidth):
     assert rssi_py == pytest.approx(rssi_cpp, abs=0.01)
     noise_cpp = ch_cpp._flora_noise_dBm(sf)
     noise_py = ch_py._flora_noise_dBm(sf)
-    snr_cpp = rssi_cpp - noise_cpp + ch_cpp.snr_offset_dB + 10 * math.log10(2 ** sf)
-    snr_py = rssi_py - noise_py + ch_py.snr_offset_dB + 10 * math.log10(2 ** sf)
+    snr_cpp = rssi_cpp - noise_cpp + ch_cpp.snr_offset_dB
+    snr_py = rssi_py - noise_py + ch_py.snr_offset_dB
     assert snr_py == pytest.approx(snr_cpp, abs=0.01)
     per_cpp = ch_cpp.packet_error_rate(snr_cpp, sf)
     per_py = ch_py.packet_error_rate(snr_py, sf)


### PR DESCRIPTION
## Summary
- ensure the flora_cpp channel reuses the LoRa noise table when computing SNR so that the native and Python PHYs agree
- update the FLoRa cross-check tests to compare SNRs without the legacy processing gain term
- document the noise/SNR debugging steps and add the rural_long_range CLI example in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb35d327ec8331aac0b2fc8d1822e5