### PR TITLE
Align FLoRa capture window with LoRaReceiver

### DIFF
--- a/docs/equations_flora.md
+++ b/docs/equations_flora.md
@@ -38,6 +38,18 @@ multi-canaux propage ce réglage à chaque attribution, garantissant que la
 matrice reste attachée aux nœuds même lorsque le masque de canaux varie en
 cours de simulation.【F:loraflexsim/launcher/multichannel.py†L8-L51】
 
+En parallèle, le récepteur FLoRa considère qu'une collision subsiste tant que
+les six derniers symboles de préambule ne sont pas reçus sans interférence
+(``nPreamble - 6``).【F:flora-master/src/LoRaPhy/LoRaReceiver.cc†L109-L170】
+LoRaFlexSim applique désormais exactement la même fenêtre : dès qu'un canal
+active les équations ou le PHY FLoRa (via `flora_mode`, un `phy_model`
+commençant par `"flora"`, `use_flora_curves` ou `flora_capture`),
+`capture_window_symbols` est forcé à 6 et cette valeur est relayée vers les
+méthodes de capture des PHY Python et OMNeT++.【F:loraflexsim/launcher/channel.py†L454-L520】【F:loraflexsim/launcher/flora_phy.py†L69-L110】【F:loraflexsim/launcher/omnet_phy.py†L474-L520】
+Les passerelles en mode `capture_mode="flora"` reproduisent ainsi la logique du
+`LoRaReceiver` original, garantissant la parité avec les traces FLoRa lors des
+collisions entre signaux de même SF.
+
 
 ### Modèle Hata‑Okumura
 

--- a/loraflexsim/launcher/flora_phy.py
+++ b/loraflexsim/launcher/flora_phy.py
@@ -78,7 +78,8 @@ class FloraPHY:
         The algorithm follows the same logic as ``LoRaReceiver`` in FLoRa:
         the strongest packet wins only if the power difference with each
         interferer is above the ``NON_ORTH_DELTA`` threshold *and* the
-        interferer overlaps past the ``preamble - 5`` symbols window.
+        interferer overlaps past the ``preamble - capture_window_symbols``
+        window (six symbols in the FLoRa configuration).
         """
 
         if not rssi_list:

--- a/loraflexsim/launcher/omnet_phy.py
+++ b/loraflexsim/launcher/omnet_phy.py
@@ -509,7 +509,8 @@ class OmnetPHY:
             end0 = end_list[idx0]
             symbol_time = (2 ** sf0) / self.channel.bandwidth
             cs_begin = start0 + symbol_time * (
-                self.channel.preamble_symbols - self.capture_window_symbols
+                self.channel.preamble_symbols
+                - self.channel.capture_window_symbols
             )
 
             captured = True


### PR DESCRIPTION
## Summary
- force Channel to adopt a six-symbol capture window whenever FLoRa curves, PHY or flora_mode are active and propagate the value to the attached PHY helpers
- update FloraPHY and OmnetPHY capture logic to rely on the shared window and document the alignment with the LoRaReceiver rules
- extend the gateway capture tests with a LoRaReceiver-style same-SF collision to lock the new behaviour in

## Testing
- pytest tests/test_gateway_capture.py

------
https://chatgpt.com/codex/tasks/task_e_68cb5d68bfe0833191a0df79337e39a8