### PR TITLE
Expose simulation status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,13 @@ fournies dans l'INI de FLoRa.
    ```bash
    uvicorn launcher.web_api:app --reload
    ```
-   L'endpoint `POST /simulations/start` accepte un JSON
-   `{"command": "start_sim", "params": {...}}` pour lancer une simulation.
-   Les métriques en temps réel sont diffusées sur le WebSocket `/ws` sous la
-   forme `{"event": "metrics", "data": {...}}`.
+   - L'endpoint `POST /simulations/start` accepte un JSON
+     `{"command": "start_sim", "params": {...}}` pour lancer une simulation.
+   - `GET /simulations/status` retourne `{"status": "idle|running|stopped", "metrics": {...}}`
+     afin de consulter l'état courant (au repos, en cours ou arrêté) et les
+     métriques cumulées.
+   - Les métriques en temps réel sont diffusées sur le WebSocket `/ws` sous la
+     forme `{"event": "metrics", "data": {...}}`.
 
 ## Reproduire FLoRa
 

--- a/docs/test_plan.md
+++ b/docs/test_plan.md
@@ -48,13 +48,14 @@ Ce document dresse la cartographie des modules critiques et des scénarios `pyte
 
 ### API (`loraflexsim/launcher/web_api.py`)
 - **Rôle :** façade FastAPI pour piloter le simulateur et diffuser les métriques en WebSocket.
-- **Tests existants :** aucun scénario automatique ne couvre l'API REST/WebSocket à ce jour.
+- **Tests existants :** `tests/test_rest_api_gap.py` vérifie la disponibilité de
+  l'endpoint `/simulations/status` et le cycle de vie complet (repos → en cours
+  → arrêté).
 
 ## Lacunes identifiées et scénarios `pytest`
 
 | Lacune | Description | Nouveau test |
 | --- | --- | --- |
-| Couverture REST | L'API n'expose pas encore d'endpoint de statut pour suivre une simulation en cours. | `tests/test_rest_api_gap.py` (marqué `xfail` tant que `/simulations/status` n'est pas implémenté). |
 | Calcul d'énergie détaillé | L'énergie de rampe PA est agrégée dans la clé `"tx"` au lieu d'être isolée. | `tests/test_energy_breakdown_gap.py` (`xfail` tant que la composante `"ramp"` n'est pas rapportée). |
 | Duty-cycle dynamique | Le `DutyCycleReq` LoRaWAN ne propage pas sa valeur vers le `DutyCycleManager`. | `tests/test_duty_cycle_gap.py` (`xfail` en attendant la mise à jour dynamique). |
 

--- a/loraflexsim/launcher/web_api.py
+++ b/loraflexsim/launcher/web_api.py
@@ -71,6 +71,22 @@ async def stop_simulation() -> Dict[str, Any]:
     return {"status": "stopped"}
 
 
+@app.get("/simulations/status")
+async def simulation_status() -> Dict[str, Any]:
+    """Return the current simulation status and the latest metrics."""
+    task = _sim_task
+    if task is not None and not task.done():
+        status = "running"
+    else:
+        status = "idle" if _sim is None else "stopped"
+    metrics: Dict[str, Any]
+    if _sim is not None:
+        metrics = _sim.get_metrics()
+    else:
+        metrics = {}
+    return {"status": status, "metrics": metrics}
+
+
 @app.websocket("/ws")
 async def metrics_stream(websocket: WebSocket) -> None:
     """Send real-time metrics over WebSocket."""

--- a/tests/test_rest_api_gap.py
+++ b/tests/test_rest_api_gap.py
@@ -1,14 +1,74 @@
-import pytest
+import asyncio
+import time
+
+import anyio
 from fastapi.routing import APIRoute
 
 from loraflexsim.launcher import web_api
 
 
-@pytest.mark.xfail(reason="Endpoint de statut REST non implémenté", strict=True)
-def test_rest_api_exposes_status_endpoint():
+def test_rest_api_status_endpoint_lifecycle() -> None:
     routes = {
         route.path
         for route in web_api.app.routes
         if isinstance(route, APIRoute)
     }
     assert "/simulations/status" in routes
+
+    async def scenario() -> None:
+        original_simulator = web_api.Simulator
+
+        class DummySimulator:
+            def __init__(self, **_: object) -> None:
+                self.running = True
+                self.metrics = {"pdr": 0.0, "ticks": 0}
+
+            def run(self) -> None:
+                while self.running:
+                    self.metrics["ticks"] += 1
+                    time.sleep(0.01)
+
+            def stop(self) -> None:
+                self.running = False
+
+            def get_metrics(self) -> dict:
+                return dict(self.metrics)
+
+        web_api.Simulator = DummySimulator
+        web_api._sim = None
+        web_api._sim_task = None
+
+        try:
+            initial_payload = await web_api.simulation_status()
+            assert initial_payload["status"] == "idle"
+            assert initial_payload["metrics"] == {}
+
+            start_payload = web_api.Command(command="start_sim", params={})
+            start_response = await web_api.start_simulation(start_payload)
+            assert start_response["status"] == "started"
+
+            await asyncio.sleep(0)
+
+            running_payload = await web_api.simulation_status()
+            assert running_payload["status"] == "running"
+            assert "pdr" in running_payload["metrics"]
+
+            stop_response = await web_api.stop_simulation()
+            assert stop_response["status"] == "stopped"
+
+            final_payload = await web_api.simulation_status()
+            assert final_payload["status"] == "stopped"
+            assert "pdr" in final_payload["metrics"]
+
+        finally:
+            try:
+                if web_api._sim is not None and web_api._sim.running:
+                    web_api._sim.stop()
+                if web_api._sim_task is not None:
+                    await web_api._sim_task
+            finally:
+                web_api._sim = None
+                web_api._sim_task = None
+                web_api.Simulator = original_simulator
+
+    anyio.run(scenario, backend="asyncio")


### PR DESCRIPTION
## Summary
- add a REST endpoint to report the current simulation status and metrics
- cover the lifecycle (idle → running → stopped) in tests/test_rest_api_gap.py with a stub simulator
- document the status route in the README and mark the gap as closed in docs/test_plan.md

## Testing
- pytest tests/test_rest_api_gap.py

------
https://chatgpt.com/codex/tasks/task_e_68cb6ffcd55c8331ae71f1852d8751d4