### PR TITLE
Track ramp energy separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -1000,6 +1000,7 @@ Les points suivants ont été intégrés à LoRaFlexSim :
 - **PDR par nœud et par type de trafic.** Chaque nœud maintient l'historique de ses vingt dernières transmissions afin de calculer un taux de livraison global et récent. Ces valeurs sont visibles dans le tableau de bord et exportées dans un fichier `metrics_*.csv`.
 - **Historique glissant et indicateurs QoS.** LoRaFlexSim calcule désormais le délai moyen de livraison ainsi que le nombre de retransmissions sur la période récente.
 - **Indicateurs supplémentaires.** La méthode `get_metrics()` retourne le PDR par SF, passerelle, classe et nœud. Le tableau de bord affiche un récapitulatif et l'export produit deux fichiers CSV : un pour les événements détaillés et un pour les métriques agrégées.
+  Les décompositions d'énergie exposent également une clé `"ramp"` dédiée aux phases de montée/descente du PA, exportée dans les CSV (`energy_ramp_J_node`) et visible dans le tableau de bord.
  - **Moteur d'événements précis.** La file de priorité gère désormais un délai réseau de 10 ms et un traitement serveur de 1,2 s, reproduisant ainsi fidèlement l'ordonnancement d'OMNeT++.
 - **Suivi détaillé des ACK.** Chaque nœud mémorise les confirmations reçues pour appliquer fidèlement la logique ADR de FLoRa.
 - **Scheduler de downlinks prioritaire.** Le module `downlink_scheduler.py` organise les transmissions B/C en donnant la priorité aux commandes et accusés de réception.

--- a/docs/test_plan.md
+++ b/docs/test_plan.md
@@ -56,7 +56,6 @@ Ce document dresse la cartographie des modules critiques et des scénarios `pyte
 
 | Lacune | Description | Nouveau test |
 | --- | --- | --- |
-| Calcul d'énergie détaillé | L'énergie de rampe PA est agrégée dans la clé `"tx"` au lieu d'être isolée. | `tests/test_energy_breakdown_gap.py` (`xfail` tant que la composante `"ramp"` n'est pas rapportée). |
 | Duty-cycle dynamique | Le `DutyCycleReq` LoRaWAN ne propage pas sa valeur vers le `DutyCycleManager`. | `tests/test_duty_cycle_gap.py` (`xfail` en attendant la mise à jour dynamique). |
 
 ## Commandes utiles
@@ -69,5 +68,7 @@ Ce document dresse la cartographie des modules critiques et des scénarios `pyte
   ```bash
   pytest tests/integration/test_validation_matrix.py
   ```
+
+Le scénario `tests/test_energy_breakdown_gap.py` vérifie désormais que la décomposition énergétique expose la composante `"ramp"`.
 
 Ce plan doit être maintenu à jour lors de l'ajout de nouvelles fonctionnalités ou de la fermeture des tests marqués `xfail`.

--- a/loraflexsim/launcher/gateway.py
+++ b/loraflexsim/launcher/gateway.py
@@ -63,6 +63,7 @@ class Gateway:
         self.energy_preamble = 0.0
         self.energy_sleep = 0.0
         self.energy_processing = 0.0
+        self.energy_ramp = 0.0
         # Accumulateur d'énergie par état
         self.energy = EnergyAccumulator()
         # Transmissions en cours indexées par (sf, frequency)
@@ -88,6 +89,8 @@ class Gateway:
             self.energy_sleep += energy_joules
         elif state == "processing":
             self.energy_processing += energy_joules
+        elif state == "ramp":
+            self.energy_ramp += energy_joules
 
     def get_energy_breakdown(self) -> dict[str, float]:
         """Retourne la consommation d'énergie par état."""

--- a/loraflexsim/launcher/omnet_phy.py
+++ b/loraflexsim/launcher/omnet_phy.py
@@ -147,11 +147,12 @@ class OmnetPHY:
         self._tx_level = 1.0 if self.tx_state == "on" else 0.0
         # Energy accumulated in Joules for each radio state.  The same
         # elementary relationship ``E = V * I * t`` is applied to
-        # transmission, reception, idle and start-up phases.
+        # transmission, reception, idle, ramp and start-up phases.
         self.energy_tx = 0.0
         self.energy_rx = 0.0
         self.energy_idle = 0.0
         self.energy_start = 0.0
+        self.energy_ramp = 0.0
 
     # ------------------------------------------------------------------
     # Transceiver state helpers
@@ -199,7 +200,11 @@ class OmnetPHY:
                 else self.tx_current_a
             )
             self.energy_start += self.voltage_v * current * dt
-        elif self.tx_state != "off":
+        elif self.tx_state in {"ramping_up", "ramping_down"}:
+            self.energy_ramp += (
+                self.voltage_v * self.tx_current_a * self._tx_level * dt
+            )
+        elif self.tx_state == "on":
             self.energy_tx += (
                 self.voltage_v * self.tx_current_a * self._tx_level * dt
             )

--- a/loraflexsim/launcher/simulator.py
+++ b/loraflexsim/launcher/simulator.py
@@ -1208,7 +1208,9 @@ class Simulator:
                 total_tx = energy_tx + ramp
                 self.energy_gateways_J += total_tx
                 self.total_energy_J += total_tx
-                gw.add_energy(total_tx, "tx")
+                gw.add_energy(energy_tx, "tx")
+                if ramp > 0.0:
+                    gw.add_energy(ramp, "ramp")
                 preamble_J = (
                     gw.profile.preamble_current_a
                     * gw.profile.voltage_v
@@ -1363,7 +1365,9 @@ class Simulator:
                 total_tx = energy_tx + ramp
                 self.energy_gateways_J += total_tx
                 self.total_energy_J += total_tx
-                gw.add_energy(total_tx, "tx")
+                gw.add_energy(energy_tx, "tx")
+                if ramp > 0.0:
+                    gw.add_energy(ramp, "ramp")
                 preamble_J = (
                     gw.profile.preamble_current_a
                     * gw.profile.voltage_v
@@ -1630,6 +1634,9 @@ class Simulator:
         df["energy_processing_J_node"] = df["node_id"].apply(
             lambda nid: node_dict[nid].energy_processing
         )
+        df["energy_ramp_J_node"] = df["node_id"].apply(
+            lambda nid: node_dict[nid].energy_ramp
+        )
         df["energy_consumed_J_node"] = df["node_id"].apply(
             lambda nid: node_dict[nid].energy_consumed
         )
@@ -1666,6 +1673,7 @@ class Simulator:
             "energy_rx_J_node",
             "energy_sleep_J_node",
             "energy_processing_J_node",
+            "energy_ramp_J_node",
             "energy_consumed_J_node",
             "battery_capacity_J",
             "battery_remaining_J",

--- a/tests/test_airtime_energy.py
+++ b/tests/test_airtime_energy.py
@@ -18,6 +18,6 @@ def test_energy_and_airtime_metrics():
     nid = node.id
     assert abs(metrics["energy_by_node"][nid] - node.energy_consumed) < 1e-9
     assert abs(metrics["airtime_by_node"][nid] - node.total_airtime) < 1e-9
-    assert metrics["energy_breakdown_by_node"][nid]["tx"] == pytest.approx(
-        node.energy_tx
-    )
+    breakdown = metrics["energy_breakdown_by_node"][nid]
+    assert breakdown["tx"] == pytest.approx(node.energy_tx)
+    assert breakdown["ramp"] == pytest.approx(node.energy_ramp)

--- a/tests/test_energy_accounting.py
+++ b/tests/test_energy_accounting.py
@@ -18,10 +18,22 @@ def test_tx_energy_accounted_once():
     node = sim.nodes[0]
     current = node.profile.get_tx_current(node.tx_power)
     airtime = node.channel.airtime(node.sf, payload_size=sim.payload_size_bytes)
-    expected_tx = current * node.profile.voltage_v * (
-        airtime + node.profile.ramp_up_s + node.profile.ramp_down_s
-    )
+    expected_tx = current * node.profile.voltage_v * airtime
     assert node.energy_tx == pytest.approx(expected_tx)
+    expected_ramp_tx = current * node.profile.voltage_v * (
+        node.profile.ramp_up_s + node.profile.ramp_down_s
+    )
+    rx_current = (
+        node.profile.listen_current_a
+        if node.profile.listen_current_a > 0.0
+        else node.profile.rx_current_a
+    )
+    expected_ramp_rx = rx_current * node.profile.voltage_v * (
+        node.profile.ramp_up_s + node.profile.ramp_down_s
+    )
+    assert node.energy_ramp == pytest.approx(
+        expected_ramp_tx + 2 * expected_ramp_rx
+    )
     expected_startup = (
         node.profile.startup_current_a
         * node.profile.voltage_v

--- a/tests/test_energy_breakdown_gap.py
+++ b/tests/test_energy_breakdown_gap.py
@@ -3,7 +3,6 @@ import pytest
 from loraflexsim.launcher.simulator import Simulator
 
 
-@pytest.mark.xfail(reason="L'énergie de rampe n'est pas exposée séparément", strict=True)
 def test_energy_breakdown_reports_pa_ramp_component():
     sim = Simulator(
         num_nodes=1,
@@ -15,5 +14,7 @@ def test_energy_breakdown_reports_pa_ramp_component():
         seed=0,
     )
     sim.run()
-    breakdown = sim.nodes[0].get_energy_breakdown()
+    node = sim.nodes[0]
+    breakdown = node.get_energy_breakdown()
     assert "ramp" in breakdown
+    assert breakdown["ramp"] == pytest.approx(node.energy_ramp)

--- a/tests/test_flora_energy.py
+++ b/tests/test_flora_energy.py
@@ -34,7 +34,14 @@ def test_cumulative_energy_matches_flora_model():
     assert node.energy_preamble == pytest.approx(
         profile.preamble_current_a * profile.voltage_v * profile.preamble_time_s
     )
+    assert node.energy_tx == pytest.approx(tx_energy)
+    assert node.energy_ramp == pytest.approx(
+        profile.get_tx_current(14.0)
+        * profile.voltage_v
+        * (profile.ramp_up_s + profile.ramp_down_s)
+    )
     breakdown = node.get_energy_breakdown()
     assert breakdown["tx"] == pytest.approx(node.energy_tx)
+    assert breakdown["ramp"] == pytest.approx(node.energy_ramp)
     assert breakdown["startup"] == pytest.approx(node.energy_startup)
     assert node.energy.total() == pytest.approx(node.energy_consumed)


### PR DESCRIPTION
## Summary
- add a dedicated ramp energy accumulator to the PHY, nodes and gateways so PA ramps are no longer merged into TX/RX totals
- expose the new `ramp` contribution in simulator metrics, CSV exports and documentation to keep external tooling compatible
- update energy-related tests to cover the ramp key and confirm the breakdown includes PA ramp and receive window costs

## Testing
- pytest tests/test_energy_accounting.py tests/test_flora_energy.py tests/test_airtime_energy.py tests/test_energy_breakdown_gap.py

------
https://chatgpt.com/codex/tasks/task_e_68cd3c1f5b888331a998adbbbec9f986