### PR TITLE
Add automatic long-range parameter suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,22 +136,37 @@ les gains d'antenne du couple passerelle/nœud pour garantir des liaisons de 10 
 disponibles sont résumés ci-dessous :
 
 | Preset CLI (`--long-range-demo <preset>`) | P<sub>TX</sub> (dBm) | Gains TX/RX (dBi) | Perte câble (dB) | Effet observé sur la PDR SF12 |
-|-------------------------------------------|---------------------:|------------------:|-----------------:|--------------------------------|
+|-------------------------------------------|---------------------:|------------------:|-----------------:|------------------------------|
 | `flora` / `flora_hata`                    |                 23.0 |             16/16 |              0.5 | ≈ 75 % : PDR limitée par la marge de sensibilité pour reproduire les mesures historiques.【F:docs/long_range.md†L15-L25】|
 | `rural_long_range`                        |                 16.0 |              6/6  |              0.5 | ≈ 96 % : combinaison adaptée aux déploiements ruraux avec une marge RSSI/SNR confortable.【F:docs/long_range.md†L15-L29】|
 | `very_long_range`                         |                 27.0 |             19/19 |              0.5 | 100 % : ajoute deux nœuds à 13,5–15 km tout en conservant la marge SF12 au-dessus des sensibilités `FLORA_SENSITIVITY`.【F:docs/long_range.md†L15-L38】|
 
+L'utilitaire `suggest_parameters(area_km2, max_distance_km)` interpole ces presets pour
+fournir automatiquement un budget de liaison adapté à une surface cible (km²) et une
+distance maximale (km). La CLI expose cette fonctionnalité via `--long-range-auto` :
+
+| Surface cible | Distance max | P<sub>TX</sub> (dBm) | Gains TX/RX (dBi) | Références ancrées | Commande |
+|---------------|--------------|---------------------:|------------------:|-------------------|----------|
+| 10 km²        | auto (1,58 km) | 16.0 | 6 / 6  | `rural_long_range → rural_long_range` | `python -m loraflexsim.run --long-range-auto 10` |
+| 576 km²       | 13 km         | 24.3 | 17 / 17 | `flora → very_long_range` | `python -m loraflexsim.run --long-range-auto 576 13` |
+| 1 024 km²     | auto (16 km)  | 27.0 | 19 / 19 | `very_long_range → very_long_range` | `python -m loraflexsim.run --long-range-auto 1024` |
+
 Exécutez `python -m loraflexsim.run --long-range-demo` pour lancer le preset
 par défaut `flora_hata` (identique à `python run.py --long-range-demo`). Ajoutez
 `rural_long_range` pour les essais de très grande portée avec un PDR SF12 plus
-élevé ou `very_long_range` pour valider des liens jusqu'à 15 km. Les métriques
-détaillées, un tableau des marges RSSI pour 10/12/15 km et un utilitaire CLI
-(`scripts/long_range_margin.py`) sont présentés dans `docs/long_range.md`.
+élévé ou `very_long_range` pour valider des liens jusqu'à 15 km. Les suggestions
+automatiques (`--long-range-auto <surface> [distance]`) permettent d'explorer des
+budgets intermédiaires. Les métriques détaillées, un tableau des marges RSSI pour
+10/12/15 km et un utilitaire CLI (`scripts/long_range_margin.py`) sont présentés
+dans `docs/long_range.md`.
 
 Le comportement attendu est verrouillé par le test d'intégration
 `pytest tests/integration/test_long_range_large_area.py`, qui s'assure que chaque
 preset conserve une PDR SF12 ≥ 70 % tout en vérifiant les marges de
-sensibilité.【F:tests/integration/test_long_range_large_area.py†L1-L63】
+sensibilité.【F:tests/integration/test_long_range_large_area.py†L1-L63】 Le test
+`test_auto_suggestion_preserves_sf12_reliability` valide en outre que
+`suggest_parameters` maintient un PDR SF12 ≥ 70 % pour une surface de 10 km² tout
+en restant dans l'enveloppe des presets existants.【F:tests/integration/test_long_range_large_area.py†L65-L88】
 
 ## Plan de vérification
 

--- a/docs/long_range.md
+++ b/docs/long_range.md
@@ -42,16 +42,32 @@ La table ci-dessous résume les marges SF12 obtenues avec la largeur de bande 12
 
 *Marge calculée via `scripts/long_range_margin.py --preset <preset> --distances 10 12 15`.
 
+Pour explorer des combinaisons intermédiaires, la fonction Python
+`suggest_parameters(area_km2, max_distance_km)` interpole ces budgets de liaison à
+partir d'une surface cible (km²) et d'une distance maximale (km). L'option
+CLI `--long-range-auto` expose directement ce calcul et lance la simulation
+associée.
+
+| Surface cible | Distance max | P<sub>TX</sub> (dBm) | Gains TX/RX (dBi) | Références ancrées | Commande CLI |
+|---------------|--------------|---------------------:|------------------:|-------------------|--------------|
+| 10 km²        | auto (1,58 km) | 16.0 | 6 / 6  | `rural_long_range → rural_long_range` | `python -m loraflexsim.run --long-range-auto 10` |
+| 576 km²       | 13 km         | 24.3 | 17 / 17 | `flora → very_long_range` | `python -m loraflexsim.run --long-range-auto 576 13` |
+| 1 024 km²     | auto (16 km)  | 27.0 | 19 / 19 | `very_long_range → very_long_range` | `python -m loraflexsim.run --long-range-auto 1024` |
+
 ## Exécution et vérification
 
 L'intégration `tests/integration/test_long_range_large_area.py` vérifie que le PDR SF12
 reste supérieur à 70 % pour les trois presets tout en contrôlant les marges de RSSI/SNR.
+Le test `test_auto_suggestion_preserves_sf12_reliability` complète ce dispositif en
+validant que `suggest_parameters` maintient un PDR SF12 ≥ 70 % pour une surface cible
+de 10 km² tout en restant aligné sur les presets historiques.
 Le scénario peut également être lancé depuis la CLI :
 
 ```bash
 python -m loraflexsim.run --long-range-demo        # preset par défaut : flora_hata
 python -m loraflexsim.run --long-range-demo flora  # forcé sur le preset log-normal
 python -m loraflexsim.run --long-range-demo very_long_range --seed 3
+python -m loraflexsim.run --long-range-auto 576 13  # interpolation auto pour 13 km sur 24x24 km
 ```
 
 ### Exemple de configuration CLI

--- a/loraflexsim/scenarios/__init__.py
+++ b/loraflexsim/scenarios/__init__.py
@@ -7,9 +7,12 @@ from .long_range import (
     LONG_RANGE_RECOMMENDATIONS,
     LONG_RANGE_SPREADING_FACTORS,
     LongRangeParameters,
+    SuggestedLongRange,
     build_long_range_simulator,
+    build_simulator_from_suggestion,
     configure_long_range_nodes,
     create_long_range_channels,
+    suggest_parameters,
 )
 
 __all__ = [
@@ -19,7 +22,10 @@ __all__ = [
     "LONG_RANGE_RECOMMENDATIONS",
     "LONG_RANGE_SPREADING_FACTORS",
     "LongRangeParameters",
+    "SuggestedLongRange",
     "build_long_range_simulator",
+    "build_simulator_from_suggestion",
     "configure_long_range_nodes",
     "create_long_range_channels",
+    "suggest_parameters",
 ]


### PR DESCRIPTION
## Summary
- add an interpolated long-range parameter suggestion helper and shared simulator builder
- expose the helper in the CLI via `--long-range-auto` and update documentation
- extend integration coverage to validate automatic suggestions maintain SF12 PDR

## Testing
- pytest tests/integration/test_long_range_large_area.py

------
https://chatgpt.com/codex/tasks/task_e_68cd517d8e108331854ddbc673ea21ae