### PR TITLE
Throttle ADR standard commands after 20 uplinks

### DIFF
--- a/loraflexsim/launcher/node.py
+++ b/loraflexsim/launcher/node.py
@@ -247,6 +247,7 @@ class Node:
 
         # ADR helper flags
         self.last_adr_ack_req: bool = False
+        self.frames_since_last_adr_command: int = 0
         self._nb_trans_left: int = 0
 
         # Poisson arrival process tracking


### PR DESCRIPTION
## Summary
- add a per-node counter of uplinks since the last ADR command
- throttle the standard ADR branch so LinkADRReq is only emitted every 20 uplinks unless ADRACKReq is set
- extend the test suite with coverage for the new throttling behaviour and adjust the FLoRa alignment test accordingly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdbda83d048331af20824d7488de82