### PR TITLE
Add class load sweep simulation script

### DIFF
--- a/scripts/mne3sd/article_a/scenarios/run_class_load_sweep.py
+++ b/scripts/mne3sd/article_a/scenarios/run_class_load_sweep.py
@@ -1,0 +1,300 @@
+"""Run a sweep to characterise LoRaWAN class load performance.
+
+This script launches the :class:`loraflexsim.launcher.simulator.Simulator` for
+classes A, B and C across multiple traffic intervals.  For each replicate the
+packet delivery ratio (PDR), collisions and energy statistics are stored in a
+CSV file for subsequent analysis.
+
+Example usage::
+
+    python scripts/mne3sd/article_a/scenarios/run_class_load_sweep.py \
+        --nodes 50 --packets 40 --replicates 10 --seed 3 --gateway 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import os
+import statistics
+import sys
+from pathlib import Path
+from typing import Iterable
+
+# Allow running the script from a clone without installation
+sys.path.insert(
+    0,
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+    ),
+)
+
+from loraflexsim.launcher import Simulator  # noqa: E402
+
+
+LOGGER = logging.getLogger("class_load_sweep")
+DEFAULT_INTERVALS = [60.0, 300.0, 900.0]
+ROOT = Path(__file__).resolve().parents[4]
+RESULTS_PATH = ROOT / "results" / "mne3sd" / "article_a" / "class_load_metrics.csv"
+
+
+def positive_int(value: str) -> int:
+    """Return ``value`` converted to a positive integer."""
+    ivalue = int(value)
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError("value must be a positive integer")
+    return ivalue
+
+
+def parse_intervals(interval: float | None, interval_list: Iterable[float] | None) -> list[float]:
+    """Combine the different interval arguments into a sorted list."""
+    values: list[float] = []
+    if interval_list:
+        values.extend(float(v) for v in interval_list)
+    if interval is not None:
+        values.append(float(interval))
+    if not values:
+        values = DEFAULT_INTERVALS.copy()
+    # Remove duplicates while preserving order
+    seen: set[float] = set()
+    ordered: list[float] = []
+    for val in values:
+        if val not in seen:
+            ordered.append(val)
+            seen.add(val)
+    return ordered
+
+
+def configure_logging(verbose: bool) -> None:
+    """Initialise logging with or without debug output."""
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(message)s")
+
+
+def compute_energy_breakdown(metrics: dict, num_nodes: int) -> tuple[float, float, float]:
+    """Return average per-node energy spent in TX, RX and sleep states."""
+    breakdown = metrics.get("energy_breakdown_by_node", {})
+    total_tx = 0.0
+    total_rx = 0.0
+    total_sleep = 0.0
+    for node_breakdown in breakdown.values():
+        total_tx += float(node_breakdown.get("tx", 0.0))
+        rx_energy = float(node_breakdown.get("rx", 0.0))
+        rx_energy += float(node_breakdown.get("listen", 0.0))
+        total_rx += rx_energy
+        total_sleep += float(node_breakdown.get("sleep", 0.0))
+    if num_nodes <= 0:
+        return 0.0, 0.0, 0.0
+    return total_tx / num_nodes, total_rx / num_nodes, total_sleep / num_nodes
+
+
+def main() -> None:  # noqa: D401 - CLI entry point
+    parser = argparse.ArgumentParser(
+        description="Run class load simulations for LoRaWAN classes A/B/C"
+    )
+    parser.add_argument("--nodes", type=positive_int, default=50, help="Number of nodes")
+    parser.add_argument(
+        "--interval",
+        type=float,
+        help="Single packet interval in seconds (additional to any list values)",
+    )
+    parser.add_argument(
+        "--interval-list",
+        type=float,
+        action="append",
+        help=(
+            "Packet interval list in seconds. May be repeated. "
+            "Defaults to 60, 300, 900 s when omitted."
+        ),
+    )
+    parser.add_argument(
+        "--packets", type=positive_int, default=40, help="Packets to send per node"
+    )
+    parser.add_argument(
+        "--replicates",
+        type=positive_int,
+        default=5,
+        help="Number of replicates for each class/interval combination",
+    )
+    parser.add_argument("--seed", type=int, default=1, help="Base random seed")
+    parser.add_argument(
+        "--gateway",
+        type=positive_int,
+        default=1,
+        help="Number of gateways for all simulations",
+    )
+    parser.add_argument(
+        "--adr-node",
+        action="store_true",
+        help="Enable ADR on the nodes",
+    )
+    parser.add_argument(
+        "--adr-server",
+        action="store_true",
+        help="Enable ADR on the server",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+    args = parser.parse_args()
+
+    configure_logging(args.verbose)
+
+    intervals = parse_intervals(args.interval, args.interval_list)
+
+    classes = ["A", "B", "C"]
+    results: list[dict[str, object]] = []
+    summary: list[dict[str, float | str]] = []
+
+    for class_type in classes:
+        LOGGER.info("=== Simulating class %s ===", class_type)
+        for interval_s in intervals:
+            replicate_rows: list[dict[str, float]] = []
+            LOGGER.info("Interval %.1f s", interval_s)
+            for replicate in range(1, args.replicates + 1):
+                seed = args.seed + replicate - 1
+                sim = Simulator(
+                    num_nodes=args.nodes,
+                    num_gateways=args.gateway,
+                    packets_to_send=args.packets,
+                    seed=seed,
+                    node_class=class_type,
+                    packet_interval=interval_s,
+                    adr_node=args.adr_node,
+                    adr_server=args.adr_server,
+                )
+                sim.run()
+                metrics = sim.get_metrics()
+
+                energy_per_node = (
+                    metrics.get("energy_nodes_J", 0.0) / args.nodes if args.nodes else 0.0
+                )
+                energy_tx, energy_rx, energy_sleep = compute_energy_breakdown(
+                    metrics, args.nodes
+                )
+                pdr = float(metrics.get("PDR", 0.0))
+                collisions = int(metrics.get("collisions", 0))
+                avg_delay = float(metrics.get("avg_delay_s", 0.0))
+                energy_class = {
+                    key: metrics[key]
+                    for key in metrics
+                    if key.startswith("energy_class_")
+                }
+
+                LOGGER.info(
+                    (
+                        "Replicate %d -> PDR %.3f, collisions %d, energy/node %.4f J "
+                        "(tx %.4f J, rx %.4f J, sleep %.4f J), class energy %s"
+                    ),
+                    replicate,
+                    pdr,
+                    collisions,
+                    energy_per_node,
+                    energy_tx,
+                    energy_rx,
+                    energy_sleep,
+                    energy_class,
+                )
+
+                replicate_rows.append(
+                    {
+                        "replicate": replicate,
+                        "pdr": pdr,
+                        "collisions": float(collisions),
+                        "energy_per_node": energy_per_node,
+                        "energy_tx": energy_tx,
+                        "energy_rx": energy_rx,
+                        "energy_sleep": energy_sleep,
+                        "avg_delay": avg_delay,
+                    }
+                )
+
+            pdr_values = [row["pdr"] for row in replicate_rows]
+            pdr_mean = statistics.mean(pdr_values)
+            pdr_std = statistics.pstdev(pdr_values) if len(pdr_values) > 1 else 0.0
+
+            energy_mean = statistics.mean(row["energy_per_node"] for row in replicate_rows)
+            collisions_mean = statistics.mean(row["collisions"] for row in replicate_rows)
+            avg_delay_mean = statistics.mean(row["avg_delay"] for row in replicate_rows)
+            energy_tx_mean = statistics.mean(row["energy_tx"] for row in replicate_rows)
+            energy_rx_mean = statistics.mean(row["energy_rx"] for row in replicate_rows)
+            energy_sleep_mean = statistics.mean(row["energy_sleep"] for row in replicate_rows)
+
+            summary.append(
+                {
+                    "class": class_type,
+                    "interval": interval_s,
+                    "pdr_mean": pdr_mean,
+                    "pdr_std": pdr_std,
+                    "energy_mean": energy_mean,
+                    "energy_tx_mean": energy_tx_mean,
+                    "energy_rx_mean": energy_rx_mean,
+                    "energy_sleep_mean": energy_sleep_mean,
+                    "collisions_mean": collisions_mean,
+                    "avg_delay_mean": avg_delay_mean,
+                }
+            )
+
+            for row in replicate_rows:
+                results.append(
+                    {
+                        "class": class_type,
+                        "interval_s": interval_s,
+                        "replicate": row["replicate"],
+                        "pdr": row["pdr"],
+                        "pdr_mean": pdr_mean,
+                        "pdr_std": pdr_std,
+                        "energy_per_node_J": row["energy_per_node"],
+                        "energy_tx_J": row["energy_tx"],
+                        "energy_rx_J": row["energy_rx"],
+                        "energy_sleep_J": row["energy_sleep"],
+                        "collisions": row["collisions"],
+                        "avg_delay_s": row["avg_delay"],
+                    }
+                )
+
+    RESULTS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [
+        "class",
+        "interval_s",
+        "replicate",
+        "pdr",
+        "pdr_mean",
+        "pdr_std",
+        "energy_per_node_J",
+        "energy_tx_J",
+        "energy_rx_J",
+        "energy_sleep_J",
+        "collisions",
+        "avg_delay_s",
+    ]
+    with RESULTS_PATH.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(results)
+
+    print(f"Results saved to {RESULTS_PATH}")
+    print()
+    print("Summary (per class and interval):")
+    header = (
+        f"{'Class':<7}{'Interval [s]':>14}{'PDR mean':>12}{'PDR std':>10}"
+        f"{'Energy/node [J]':>18}{'Tx [J]':>10}{'Rx [J]':>10}{'Sleep [J]':>12}"
+        f"{'Collisions':>12}{'Avg delay [s]':>16}"
+    )
+    print(header)
+    print("-" * len(header))
+    for entry in summary:
+        print(
+            f"{entry['class']:<7}{entry['interval']:>14.1f}{entry['pdr_mean']:>12.3f}"
+            f"{entry['pdr_std']:>10.3f}{entry['energy_mean']:>18.4f}"
+            f"{entry['energy_tx_mean']:>10.4f}{entry['energy_rx_mean']:>10.4f}"
+            f"{entry['energy_sleep_mean']:>12.4f}{entry['collisions_mean']:>12.2f}"
+            f"{entry['avg_delay_mean']:>16.3f}"
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()


### PR DESCRIPTION
## Summary
- add a scenario helper to run class A/B/C load sweeps with configurable intervals, nodes and ADR options
- compute per-replicate metrics, aggregate statistics and emit both CSV output and a console summary

## Testing
- python scripts/mne3sd/article_a/scenarios/run_class_load_sweep.py --nodes 2 --packets 1 --replicates 1 --interval 5 --gateway 1


------
https://chatgpt.com/codex/tasks/task_e_68d34f2bc82c8331a6cb3cd752f64919