### PR TITLE
Add plotting utility for mobility speed sweep metrics

### DIFF
--- a/scripts/mne3sd/article_b/plots/plot_mobility_speed_metrics.py
+++ b/scripts/mne3sd/article_b/plots/plot_mobility_speed_metrics.py
@@ -1,0 +1,310 @@
+"""Plot mobility speed sweep metrics for the MNE3SD article B analysis."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[4]
+RESULTS_PATH = ROOT / "results" / "mne3sd" / "article_b" / "mobility_speed_metrics.csv"
+FIGURES_DIR = ROOT / "figures" / "mne3sd" / "article_b"
+
+
+def apply_plot_style(style: str | None) -> None:
+    """Apply a compact IEEE-inspired plotting style unless overridden."""
+
+    plt.rcdefaults()
+    if style:
+        plt.style.use(style)
+        return
+
+    plt.rcParams.update(
+        {
+            "font.size": 8,
+            "axes.labelsize": 8,
+            "axes.titlesize": 8,
+            "xtick.labelsize": 8,
+            "ytick.labelsize": 8,
+            "legend.fontsize": 7,
+            "figure.figsize": (3.5, 2.2),
+        }
+    )
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Return the parsed command line arguments."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate grouped bar charts for PDR and average delay from the mobility "
+            "speed sweep metrics. Optionally include a heatmap summarising PDR versus "
+            "communication range when multiple ranges are present."
+        )
+    )
+    parser.add_argument(
+        "--results",
+        type=Path,
+        default=RESULTS_PATH,
+        help="Path to the mobility_speed_metrics.csv file",
+    )
+    parser.add_argument(
+        "--style",
+        help="Matplotlib style name or .mplstyle path to override the default settings",
+    )
+    parser.add_argument(
+        "--dpi",
+        type=int,
+        default=300,
+        help="Dots per inch for the exported figures (defaults to 300 dpi)",
+    )
+    parser.add_argument(
+        "--show",
+        action="store_true",
+        help="Display the figures instead of running in batch mode",
+    )
+    return parser.parse_args()
+
+
+def _coerce_numeric(df: pd.DataFrame, columns: Iterable[str]) -> None:
+    """Convert the provided columns to numeric values in-place when present."""
+
+    for column in columns:
+        if column in df.columns:
+            df[column] = pd.to_numeric(df[column], errors="coerce")
+
+
+def load_metrics(path: Path) -> pd.DataFrame:
+    """Return the aggregated metrics required for plotting."""
+
+    df = pd.read_csv(path)
+    if df.empty:
+        raise ValueError("No rows found in the metrics CSV")
+
+    required_columns = {"model", "speed_profile"}
+    missing = required_columns.difference(df.columns)
+    if missing:
+        missing_cols = ", ".join(sorted(missing))
+        raise ValueError(f"Missing required columns: {missing_cols}")
+
+    _coerce_numeric(
+        df,
+        (
+            "pdr",
+            "pdr_mean",
+            "avg_delay_s",
+            "avg_delay_s_mean",
+            "range_km",
+        ),
+    )
+
+    replicate_column = df.get("replicate")
+    if replicate_column is not None:
+        aggregate_mask = replicate_column.astype(str).str.lower() == "aggregate"
+        aggregated = df[aggregate_mask].copy()
+    else:
+        aggregated = pd.DataFrame()
+
+    if aggregated.empty:
+        aggregations: dict[str, str] = {"pdr": "mean", "avg_delay_s": "mean"}
+        if "range_km" in df.columns:
+            aggregations["range_km"] = "mean"
+        grouped = df.groupby(["model", "speed_profile"], as_index=False).agg(aggregations)
+        aggregated = grouped.rename(
+            columns={"pdr": "pdr_mean", "avg_delay_s": "avg_delay_s_mean"}
+        )
+
+    pdr_column = next(
+        (
+            column
+            for column in ("pdr_mean", "pdr")
+            if column in aggregated.columns and aggregated[column].notna().any()
+        ),
+        None,
+    )
+    if pdr_column is None:
+        raise ValueError("Unable to locate a column with PDR values")
+
+    delay_column = next(
+        (
+            column
+            for column in ("avg_delay_s_mean", "avg_delay_s")
+            if column in aggregated.columns and aggregated[column].notna().any()
+        ),
+        None,
+    )
+    if delay_column is None:
+        raise ValueError("Unable to locate a column with average delay values")
+
+    aggregated = aggregated.copy()
+    aggregated["model"] = aggregated["model"].astype(str)
+    aggregated["speed_profile"] = aggregated["speed_profile"].astype(str)
+    aggregated["model_label"] = aggregated["model"].str.replace("_", " ").str.title()
+
+    pdr_values = aggregated[pdr_column].astype(float)
+    if pdr_values.max() <= 1.5:
+        aggregated["pdr_percent"] = pdr_values * 100.0
+        aggregated["pdr_label"] = "PDR (%)"
+    else:
+        aggregated["pdr_percent"] = pdr_values
+        aggregated["pdr_label"] = "PDR"
+
+    aggregated["avg_delay_s_value"] = aggregated[delay_column].astype(float)
+
+    if "range_km" in aggregated.columns:
+        aggregated["range_km"] = aggregated["range_km"].astype(float)
+
+    return aggregated
+
+
+def plot_grouped_bars(
+    df: pd.DataFrame,
+    value_column: str,
+    ylabel: str,
+    title: str,
+    output_base: Path,
+    dpi: int,
+    value_format: str,
+    ylim: tuple[float, float] | None = None,
+) -> None:
+    """Plot grouped bar charts where bars are separated by model."""
+
+    pivot = df.pivot_table(
+        index="speed_profile",
+        columns="model_label",
+        values=value_column,
+        aggfunc="mean",
+    )
+    pivot = pivot.sort_index()
+    pivot = pivot[pivot.columns.sort_values()]
+
+    num_profiles = len(pivot.index)
+    fig_width = max(3.5, 0.75 * num_profiles)
+    fig, ax = plt.subplots(figsize=(fig_width, 2.6))
+
+    pivot.plot(kind="bar", ax=ax, width=0.75)
+    ax.set_xlabel("Speed profile")
+    ax.set_ylabel(ylabel)
+    ax.set_title(title)
+    if ylim is not None:
+        ax.set_ylim(*ylim)
+    ax.grid(axis="y", linestyle="--", linewidth=0.5, alpha=0.7)
+    ax.set_axisbelow(True)
+    ax.legend(title="Mobility model", loc="best")
+
+    for container in ax.containers:
+        ax.bar_label(container, fmt=value_format, padding=2, fontsize=7)
+
+    fig.tight_layout()
+    save_figure(fig, output_base, dpi)
+
+
+def plot_heatmap(df: pd.DataFrame, output_base: Path, dpi: int) -> None:
+    """Plot a heatmap of PDR versus communication range when available."""
+
+    if "range_km" not in df.columns:
+        return
+
+    ranges = df["range_km"].dropna().unique()
+    if len(ranges) <= 1:
+        return
+
+    pivot = df.pivot_table(
+        index="speed_profile",
+        columns="range_km",
+        values="pdr_percent",
+        aggfunc="mean",
+    )
+    pivot = pivot.sort_index()
+    pivot = pivot[sorted(pivot.columns)]
+
+    fig, ax = plt.subplots(figsize=(3.5, 2.6))
+    im = ax.imshow(pivot.values, aspect="auto", cmap="viridis")
+
+    ax.set_xticks(range(len(pivot.columns)))
+    ax.set_xticklabels([f"{col:g}" for col in pivot.columns])
+    ax.set_xlabel("Communication range (km)")
+    ax.set_yticks(range(len(pivot.index)))
+    ax.set_yticklabels(pivot.index)
+    ax.set_ylabel("Speed profile")
+    ax.set_title("PDR by speed profile and range")
+
+    for y, profile in enumerate(pivot.index):
+        for x, rng in enumerate(pivot.columns):
+            value = pivot.loc[profile, rng]
+            if np.isnan(value):
+                label = ""
+                text_color = "white"
+            elif value >= 99.95:
+                label = "≈100"
+                text_color = "white"
+            else:
+                label = f"{value:.1f}"
+                text_color = "white" if value >= 50 else "black"
+            ax.text(x, y, label, ha="center", va="center", color=text_color, fontsize=7)
+
+    cbar = fig.colorbar(im, ax=ax)
+    cbar.set_label("PDR (%)")
+
+    fig.tight_layout()
+    save_figure(fig, output_base, dpi)
+
+
+def save_figure(fig: plt.Figure, base_path: Path, dpi: int) -> None:
+    """Save ``fig`` to ``base_path`` as PNG and EPS files."""
+
+    base_path.parent.mkdir(parents=True, exist_ok=True)
+    png_path = base_path.with_suffix(".png")
+    fig.savefig(png_path, dpi=dpi, bbox_inches="tight")
+    print(f"Saved {png_path}")
+    eps_path = base_path.with_suffix(".eps")
+    fig.savefig(eps_path, dpi=dpi, format="eps", bbox_inches="tight")
+    print(f"Saved {eps_path}")
+    plt.close(fig)
+
+
+def main() -> None:  # pragma: no cover - CLI entry point
+    args = parse_arguments()
+
+    apply_plot_style(args.style)
+
+    metrics = load_metrics(args.results)
+
+    pdr_label = metrics["pdr_label"].iloc[0]
+    pdr_ylim = (0, 105) if pdr_label.endswith("%)") else None
+
+    pdr_format = "{:.1f}" if pdr_ylim else "{:.3f}"
+
+    plot_grouped_bars(
+        metrics,
+        "pdr_percent",
+        pdr_label,
+        "PDR by speed profile",
+        FIGURES_DIR / "pdr_by_speed_profile",
+        args.dpi,
+        pdr_format,
+        ylim=pdr_ylim,
+    )
+
+    plot_grouped_bars(
+        metrics,
+        "avg_delay_s_value",
+        "Average delay (s)",
+        "Average delay by speed profile",
+        FIGURES_DIR / "average_delay_by_speed_profile",
+        args.dpi,
+        "{:.2f}",
+    )
+
+    plot_heatmap(metrics, FIGURES_DIR / "pdr_heatmap_speed_profile_range", args.dpi)
+
+    if args.show:
+        plt.show()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- add a plotting script that reads mobility_speed_metrics.csv and builds grouped bar charts for PDR and average delay
- support optional PDR heatmap generation when multiple communication ranges are present and export figures as PNG and EPS with configurable DPI

## Testing
- python -m compileall scripts/mne3sd/article_b/plots/plot_mobility_speed_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68d36ef5b4b88331aa79575b86474d27