### PR TITLE
Add shared helpers for MNE3SD scripts

### DIFF
--- a/scripts/mne3sd/__init__.py
+++ b/scripts/mne3sd/__init__.py
@@ -1,0 +1,17 @@
+"""Utilities and shared helpers for MNE3SD analysis scripts."""
+
+from .common import (
+    apply_ieee_style,
+    ensure_directory,
+    save_figure,
+    summarise_metrics,
+    write_csv,
+)
+
+__all__ = [
+    "apply_ieee_style",
+    "ensure_directory",
+    "save_figure",
+    "summarise_metrics",
+    "write_csv",
+]

--- a/scripts/mne3sd/article_a/plots/plot_class_load_results.py
+++ b/scripts/mne3sd/article_a/plots/plot_class_load_results.py
@@ -3,34 +3,20 @@
 from __future__ import annotations
 
 import argparse
+import os
+import sys
 from pathlib import Path
 
 import matplotlib.pyplot as plt
 import pandas as pd
 
 ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, os.fspath(ROOT))
+
+from scripts.mne3sd.common import apply_ieee_style, save_figure
+
 RESULTS_PATH = ROOT / "results" / "mne3sd" / "article_a" / "class_load_metrics.csv"
 FIGURES_DIR = ROOT / "figures" / "mne3sd" / "article_a"
-
-
-def apply_plot_style(style: str | None) -> None:
-    """Apply the default IEEE-inspired plotting style unless overridden."""
-    plt.rcdefaults()
-    if style:
-        plt.style.use(style)
-        return
-
-    plt.rcParams.update(
-        {
-            "font.size": 8,
-            "axes.labelsize": 8,
-            "axes.titlesize": 8,
-            "xtick.labelsize": 8,
-            "ytick.labelsize": 8,
-            "legend.fontsize": 7,
-            "figure.figsize": (3.5, 2.2),
-        }
-    )
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -102,7 +88,7 @@ def plot_energy_by_interval(df: pd.DataFrame, output_dir: Path) -> None:
     ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.7)
     fig.tight_layout()
 
-    save_figure(fig, output_dir / "class_energy_vs_interval")
+    save_figure(fig, "class_energy_vs_interval", output_dir)
 
 
 def plot_pdr_by_interval(df: pd.DataFrame, output_dir: Path) -> None:
@@ -137,24 +123,15 @@ def plot_pdr_by_interval(df: pd.DataFrame, output_dir: Path) -> None:
     ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.7)
     fig.tight_layout()
 
-    save_figure(fig, output_dir / "class_pdr_vs_interval")
-
-
-def save_figure(fig: plt.Figure, base_path: Path) -> None:
-    """Save ``fig`` to ``base_path`` as PNG and EPS files."""
-    base_path.parent.mkdir(parents=True, exist_ok=True)
-    png_path = base_path.with_suffix(".png")
-    fig.savefig(png_path, dpi=300, bbox_inches="tight")
-    print(f"Saved {png_path}")
-    eps_path = base_path.with_suffix(".eps")
-    fig.savefig(eps_path, dpi=300, format="eps", bbox_inches="tight")
-    print(f"Saved {eps_path}")
+    save_figure(fig, "class_pdr_vs_interval", output_dir)
 
 
 def main() -> None:
     args = parse_arguments()
 
-    apply_plot_style(args.style)
+    apply_ieee_style()
+    if args.style:
+        plt.style.use(args.style)
 
     metrics = load_metrics(args.results)
 

--- a/scripts/mne3sd/article_b/plots/plot_mobility_range_metrics.py
+++ b/scripts/mne3sd/article_b/plots/plot_mobility_range_metrics.py
@@ -3,35 +3,20 @@
 from __future__ import annotations
 
 import argparse
+import os
+import sys
 from pathlib import Path
 
 import matplotlib.pyplot as plt
 import pandas as pd
 
 ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, os.fspath(ROOT))
+
+from scripts.mne3sd.common import apply_ieee_style, save_figure
+
 RESULTS_PATH = ROOT / "results" / "mne3sd" / "article_b" / "mobility_range_metrics.csv"
 FIGURES_DIR = ROOT / "figures" / "mne3sd" / "article_b"
-
-
-def apply_plot_style(style: str | None) -> None:
-    """Apply the default IEEE-inspired plotting style unless overridden."""
-
-    plt.rcdefaults()
-    if style:
-        plt.style.use(style)
-        return
-
-    plt.rcParams.update(
-        {
-            "font.size": 8,
-            "axes.labelsize": 8,
-            "axes.titlesize": 8,
-            "xtick.labelsize": 8,
-            "ytick.labelsize": 8,
-            "legend.fontsize": 7,
-            "figure.figsize": (3.5, 2.2),
-        }
-    )
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -149,7 +134,7 @@ def plot_pdr_vs_range(
     ax.legend()
     fig.tight_layout()
 
-    save_figure(fig, output_dir / "pdr_vs_communication_range")
+    save_figure(fig, "pdr_vs_communication_range", output_dir)
 
 
 def plot_delay_vs_range(df: pd.DataFrame, output_dir: Path) -> None:
@@ -173,25 +158,15 @@ def plot_delay_vs_range(df: pd.DataFrame, output_dir: Path) -> None:
     ax.legend()
     fig.tight_layout()
 
-    save_figure(fig, output_dir / "average_delay_vs_communication_range")
-
-
-def save_figure(fig: plt.Figure, base_path: Path) -> None:
-    """Save ``fig`` to ``base_path`` as PNG and EPS files."""
-
-    base_path.parent.mkdir(parents=True, exist_ok=True)
-    png_path = base_path.with_suffix(".png")
-    fig.savefig(png_path, dpi=300, bbox_inches="tight")
-    print(f"Saved {png_path}")
-    eps_path = base_path.with_suffix(".eps")
-    fig.savefig(eps_path, dpi=300, format="eps", bbox_inches="tight")
-    print(f"Saved {eps_path}")
+    save_figure(fig, "average_delay_vs_communication_range", output_dir)
 
 
 def main() -> None:  # pragma: no cover - CLI entry point
     args = parse_arguments()
 
-    apply_plot_style(args.style)
+    apply_ieee_style()
+    if args.style:
+        plt.style.use(args.style)
 
     metrics = load_metrics(args.results)
 

--- a/scripts/mne3sd/common.py
+++ b/scripts/mne3sd/common.py
@@ -1,0 +1,114 @@
+"""Shared helper utilities for MNE3SD scripts."""
+
+from __future__ import annotations
+
+import csv
+import statistics
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import matplotlib.pyplot as plt
+
+
+def ensure_directory(path: str | Path) -> Path:
+    """Ensure that ``path`` exists and return the created directory."""
+
+    directory = Path(path)
+    if directory.suffix and not directory.is_dir():
+        directory = directory.parent
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def apply_ieee_style(figsize: tuple[float, float] = (3.5, 2.2)) -> None:
+    """Apply a compact IEEE-friendly Matplotlib style."""
+
+    plt.rcdefaults()
+    plt.rcParams.update(
+        {
+            "font.size": 8,
+            "axes.labelsize": 8,
+            "axes.titlesize": 8,
+            "xtick.labelsize": 8,
+            "ytick.labelsize": 8,
+            "legend.fontsize": 7,
+            "figure.figsize": figsize,
+        }
+    )
+
+
+def save_figure(
+    fig: "plt.Figure",
+    basename: str | Path,
+    output_dir: str | Path,
+    *,
+    dpi: int = 300,
+) -> tuple[Path, Path]:
+    """Save ``fig`` as PNG and EPS files inside ``output_dir``."""
+
+    output_base = ensure_directory(output_dir) / Path(basename)
+    png_path = output_base.with_suffix(".png")
+    fig.savefig(png_path, dpi=dpi, bbox_inches="tight")
+    eps_path = output_base.with_suffix(".eps")
+    fig.savefig(eps_path, dpi=dpi, format="eps", bbox_inches="tight")
+    return png_path, eps_path
+
+
+def write_csv(
+    path: str | Path,
+    fieldnames: Sequence[str],
+    rows: Iterable[Mapping[str, Any]] | Iterable[dict[str, Any]],
+) -> Path:
+    """Write ``rows`` to ``path`` using the provided ``fieldnames``."""
+
+    file_path = Path(path)
+    ensure_directory(file_path.parent)
+    with file_path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+    return file_path
+
+
+def summarise_metrics(
+    data: Iterable[Mapping[str, Any]],
+    group_keys: Sequence[str],
+    value_keys: Sequence[str],
+) -> list[dict[str, Any]]:
+    """Return mean and population standard deviation for ``value_keys``."""
+
+    grouped: dict[tuple[Any, ...], list[Mapping[str, Any]]] = defaultdict(list)
+    for entry in data:
+        key = tuple(entry.get(group_key) for group_key in group_keys)
+        grouped[key].append(entry)
+
+    summaries: list[dict[str, Any]] = []
+    for key, entries in grouped.items():
+        summary = {group_key: value for group_key, value in zip(group_keys, key)}
+        for value_key in value_keys:
+            values: list[float] = []
+            for entry in entries:
+                value = entry.get(value_key)
+                if isinstance(value, (int, float)):
+                    values.append(float(value))
+                elif isinstance(value, str):
+                    stripped = value.strip()
+                    if stripped:
+                        try:
+                            values.append(float(stripped))
+                        except ValueError:
+                            continue
+            if values:
+                summary[f"{value_key}_mean"] = statistics.fmean(values)
+                summary[f"{value_key}_std"] = (
+                    statistics.pstdev(values) if len(values) > 1 else 0.0
+                )
+            else:
+                summary[f"{value_key}_mean"] = ""
+                summary[f"{value_key}_std"] = ""
+        summaries.append(summary)
+    return summaries
+


### PR DESCRIPTION
## Summary
- add a shared `scripts.mne3sd.common` module providing directory management, CSV writing, figure exports and metric aggregation helpers
- refactor the MNE3SD scenario scripts to rely on the shared helpers for CSV generation and summary statistics, removing bespoke code
- update the plotting utilities to use the common IEEE style and figure saving helpers for consistent output

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d3731d591c833185d5ccf42d9da0c5