### PR TITLE
Ensure energy accounting matches E=VIt and add class benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -893,6 +893,7 @@ python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv
 python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv --allowed 50,1 200,3
 python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv --scenarios n50_c1_static n50_c1_mobile
 python scripts/plot_mobility_latency_energy.py results/mobility_latency_energy.csv
+python scripts/benchmark_energy_classes.py --nodes 20 --packets 5 --output results/energy_classes.csv
 ```
 
 `plot_sf_distribution.py` generates `sf_distribution` in PNG, JPG and EPS,
@@ -906,6 +907,11 @@ scenarios.
 `plot_mobility_latency_energy.py` creates `pdr_vs_scenario.svg`,
 `avg_delay_vs_scenario.svg` and `avg_energy_per_node_vs_scenario.svg` as
 vector graphics.
+
+`benchmark_energy_classes.py` exécute trois simulations dédiées (classes A,
+B et C) et exporte un fichier CSV contenant la consommation totale et la
+décomposition TX/RX/veille, ce qui permet de comparer rapidement les profils
+énergétiques.
 
 ## Calcul de l'airtime
 

--- a/docs/energy_profiles.md
+++ b/docs/energy_profiles.md
@@ -1,0 +1,49 @@
+# Profils énergétiques et conservation E = V·I·t
+
+LoRaFlexSim s'appuie sur des `EnergyProfile` pour calculer l'énergie
+consommée par chaque nœud.  Chaque profil définit une tension d'alimentation,
+des courants caractéristiques (`sleep`, `rx`, `listen`, `processing`) ainsi
+qu'une table reliant la puissance d'émission au courant TX.  Les phases
+transitoires propres à la radio (montée/descente du PA, démarrage, préambule)
+peuvent également être décrites via les attributs `ramp_*`, `startup_*` et
+`preamble_*`.
+
+Depuis la version courante, toutes les transitions vers les états radio
+principaux (TX, RX/écoute, veille) sont recalculées via la méthode
+`EnergyProfile.enforce_energy`.  Lorsqu'une durée `t` est fournie à
+`Node.add_energy(..., duration_s=t)`, le moteur compare l'énergie transmise
+avec la formule physique `E = V · I · t` et remplace automatiquement la valeur
+si nécessaire.  Les tests `tests/test_energy_conservation.py` vérifient ce
+comportement pour chaque état.
+
+Pour rappel :
+
+- `EnergyProfile.current_for(state)` retourne le courant associé à un état.
+- `EnergyProfile.energy_for(state, duration_s, power_dBm)` calcule l'énergie
+  attendue pour une durée donnée.
+- `EnergyProfile.enforce_energy(...)` garantit la conservation d'énergie en
+  recadrant l'accumulation.
+
+Les compteurs exportés dans les CSV et le tableau de bord distinguent les
+composantes `tx`, `rx/listen`, `sleep`, `processing`, `startup`, `preamble` et
+`ramp`, ce qui facilite l'analyse fine des profils.
+
+## Benchmarks par classe LoRaWAN
+
+Le script [`scripts/benchmark_energy_classes.py`](../scripts/benchmark_energy_classes.py)
+permet de comparer rapidement les classes A, B et C.  Il lance trois
+simulations indépendantes avec les paramètres fournis et exporte un CSV
+contenant :
+
+- le PDR agrégé,
+- l'énergie totale consommée (`energy_nodes_J`) et moyenne par nœud,
+- les composantes TX/RX/veille agrégées.
+
+Exemple d'utilisation :
+
+```bash
+python scripts/benchmark_energy_classes.py --nodes 20 --packets 5 --output results/energy_classes.csv
+```
+
+Le fichier généré peut ensuite être tracé avec un tableur ou un outil dédié
+afin de documenter et comparer les profils de consommation.

--- a/loraflexsim/launcher/simulator.py
+++ b/loraflexsim/launcher/simulator.py
@@ -987,7 +987,7 @@ class Simulator:
             current_a = node.profile.get_tx_current(tx_power)
             energy_J = current_a * node.profile.voltage_v * duration
             prev = node.energy_consumed
-            node.add_energy(energy_J, "tx")
+            node.add_energy(energy_J, "tx", duration_s=duration)
             delta = node.energy_consumed - prev
             self.total_energy_J += delta
             self.energy_nodes_J += delta
@@ -1309,9 +1309,16 @@ class Simulator:
                     * node.profile.voltage_v
                     * node.profile.rx_window_duration
                 )
-                self.energy_nodes_J += energy_J
-                self.total_energy_J += energy_J
-                node.add_energy(energy_J, state)
+                prev_energy = node.energy_consumed
+                node.add_energy(
+                    energy_J,
+                    state,
+                    duration_s=node.profile.rx_window_duration,
+                )
+                delta = node.energy_consumed - prev_energy
+                if delta > 0.0:
+                    self.energy_nodes_J += delta
+                    self.total_energy_J += delta
             if not node.alive:
                 return True
             node.last_state_time = time + (
@@ -1363,9 +1370,16 @@ class Simulator:
                     extra_time = max(duration_dl - node.profile.rx_window_duration, 0.0)
                     if extra_time > 0.0:
                         extra_energy = current * node.profile.voltage_v * extra_time
-                        self.energy_nodes_J += extra_energy
-                        self.total_energy_J += extra_energy
-                        node.add_energy(extra_energy, state)
+                        prev_energy = node.energy_consumed
+                        node.add_energy(
+                            extra_energy,
+                            state,
+                            duration_s=extra_time,
+                        )
+                        delta = node.energy_consumed - prev_energy
+                        if delta > 0.0:
+                            self.energy_nodes_J += delta
+                            self.total_energy_J += delta
                 distance = node.distance_to(gw)
                 kwargs = {
                     "freq_offset_hz": 0.0,
@@ -1466,9 +1480,16 @@ class Simulator:
                 * node.profile.voltage_v
                 * node.profile.rx_window_duration
             )
-            self.energy_nodes_J += energy_J
-            self.total_energy_J += energy_J
-            node.add_energy(energy_J, state)
+            prev_energy = node.energy_consumed
+            node.add_energy(
+                energy_J,
+                state,
+                duration_s=node.profile.rx_window_duration,
+            )
+            delta = node.energy_consumed - prev_energy
+            if delta > 0.0:
+                self.energy_nodes_J += delta
+                self.total_energy_J += delta
             if not node.alive:
                 return True
             node.last_state_time = time + node.profile.rx_window_duration
@@ -1519,9 +1540,16 @@ class Simulator:
                 extra_time = max(duration_dl - node.profile.rx_window_duration, 0.0)
                 if extra_time > 0.0:
                     extra_energy = current * node.profile.voltage_v * extra_time
-                    self.energy_nodes_J += extra_energy
-                    self.total_energy_J += extra_energy
-                    node.add_energy(extra_energy, state)
+                    prev_energy = node.energy_consumed
+                    node.add_energy(
+                        extra_energy,
+                        state,
+                        duration_s=extra_time,
+                    )
+                    delta = node.energy_consumed - prev_energy
+                    if delta > 0.0:
+                        self.energy_nodes_J += delta
+                        self.total_energy_J += delta
                 distance = node.distance_to(gw)
                 kwargs = {"freq_offset_hz": 0.0, "sync_offset_s": 0.0}
                 if hasattr(node.channel, "_obstacle_loss"):

--- a/scripts/benchmark_energy_classes.py
+++ b/scripts/benchmark_energy_classes.py
@@ -1,0 +1,157 @@
+"""Benchmark energy consumption for LoRaWAN classes A/B/C."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+from typing import Iterable
+
+from loraflexsim.launcher.simulator import Simulator
+
+DEFAULT_OUTPUT = Path("results/energy_classes.csv")
+
+
+def run_benchmark(
+    *,
+    nodes: int,
+    gateways: int,
+    area_size: float,
+    packet_interval: float,
+    packets_to_send: int,
+    mode: str,
+    seed: int,
+    duty_cycle: float | None,
+    output: Path,
+) -> Path:
+    """Run the benchmark for each LoRaWAN class and export a CSV report."""
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fields = [
+        "class",
+        "pdr",
+        "energy_nodes_J",
+        "energy_per_node_J",
+        "energy_tx_J",
+        "energy_rx_J",
+        "energy_sleep_J",
+        "energy_ramp_J",
+        "energy_startup_J",
+        "energy_preamble_J",
+        "energy_processing_J",
+        "energy_listen_J",
+    ]
+    rows: list[dict[str, float | str]] = []
+    for cls in ("A", "B", "C"):
+        sim = Simulator(
+            num_nodes=nodes,
+            num_gateways=gateways,
+            area_size=area_size,
+            transmission_mode=mode,
+            packet_interval=packet_interval,
+            packets_to_send=packets_to_send,
+            duty_cycle=duty_cycle,
+            mobility=False,
+            node_class=cls,
+            seed=seed,
+        )
+        sim.run()
+        metrics = sim.get_metrics()
+        per_node = metrics["energy_nodes_J"] / nodes if nodes > 0 else 0.0
+        breakdown = _aggregate_states(metrics["energy_breakdown_by_node"].values())
+        rows.append(
+            {
+                "class": cls,
+                "pdr": metrics["PDR"],
+                "energy_nodes_J": metrics["energy_nodes_J"],
+                "energy_per_node_J": per_node,
+                "energy_tx_J": breakdown.get("tx", 0.0),
+                "energy_rx_J": breakdown.get("rx", 0.0),
+                "energy_sleep_J": breakdown.get("sleep", 0.0),
+                "energy_ramp_J": breakdown.get("ramp", 0.0),
+                "energy_startup_J": breakdown.get("startup", 0.0),
+                "energy_preamble_J": breakdown.get("preamble", 0.0),
+                "energy_processing_J": breakdown.get("processing", 0.0),
+                "energy_listen_J": breakdown.get("listen", 0.0),
+            }
+        )
+    with output.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+    return output
+
+
+def _aggregate_states(breakdowns: Iterable[dict[str, float]]) -> dict[str, float]:
+    totals: dict[str, float] = {}
+    for entry in breakdowns:
+        for state, value in entry.items():
+            totals[state] = totals.get(state, 0.0) + value
+    return totals
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate energy benchmarks for LoRaWAN classes A/B/C",
+    )
+    parser.add_argument("--nodes", type=int, default=10, help="Number of nodes")
+    parser.add_argument("--gateways", type=int, default=1, help="Number of gateways")
+    parser.add_argument(
+        "--area",
+        type=float,
+        default=1000.0,
+        help="Deployment area size (meters)",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=60.0,
+        help="Packet interval in seconds",
+    )
+    parser.add_argument(
+        "--packets",
+        type=int,
+        default=10,
+        help="Packets to send per node (0 for continuous mode)",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["Periodic", "Random"],
+        default="Periodic",
+        help="Transmission mode",
+    )
+    parser.add_argument("--seed", type=int, default=1, help="Base RNG seed")
+    parser.add_argument(
+        "--duty-cycle",
+        type=float,
+        default=0.01,
+        help="Maximum duty cycle (set to 0 to disable)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Output CSV path",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> Path:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    duty_cycle = None if args.duty_cycle == 0 else args.duty_cycle
+    return run_benchmark(
+        nodes=args.nodes,
+        gateways=args.gateways,
+        area_size=args.area,
+        packet_interval=args.interval,
+        packets_to_send=args.packets,
+        mode=args.mode,
+        seed=args.seed,
+        duty_cycle=duty_cycle,
+        output=args.output,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry-point
+    main()

--- a/tests/test_benchmark_energy_classes.py
+++ b/tests/test_benchmark_energy_classes.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import csv
+
+from scripts import benchmark_energy_classes
+
+
+def test_benchmark_energy_classes(tmp_path) -> None:
+    out = tmp_path / "energy.csv"
+    result = benchmark_energy_classes.main(
+        [
+            "--nodes",
+            "1",
+            "--packets",
+            "1",
+            "--interval",
+            "1.0",
+            "--output",
+            str(out),
+            "--mode",
+            "Periodic",
+            "--seed",
+            "2",
+            "--duty-cycle",
+            "0.0",
+        ]
+    )
+    assert Path(result) == out
+    assert out.exists()
+    with out.open() as handle:
+        reader = csv.DictReader(handle)
+        rows = list(reader)
+    assert [row["class"] for row in rows] == ["A", "B", "C"]
+    for row in rows:
+        total = float(row["energy_nodes_J"])
+        assert total >= 0.0
+        assert float(row["energy_per_node_J"]) >= 0.0
+        energy_states = [
+            float(value)
+            for key, value in row.items()
+            if key.startswith("energy_")
+            and key not in {"energy_nodes_J", "energy_per_node_J"}
+        ]
+        assert energy_states
+        assert abs(sum(energy_states) - total) <= 1e-6 + 1e-3 * total

--- a/tests/test_energy_conservation.py
+++ b/tests/test_energy_conservation.py
@@ -1,0 +1,59 @@
+import pytest
+
+from loraflexsim.launcher.channel import Channel
+from loraflexsim.launcher.energy_profiles import EnergyProfile
+from loraflexsim.launcher.node import Node
+
+
+@pytest.fixture()
+def energy_profile() -> EnergyProfile:
+    return EnergyProfile(
+        voltage_v=3.0,
+        sleep_current_a=1e-3,
+        rx_current_a=2e-3,
+        listen_current_a=0.0,
+        process_current_a=1.5e-3,
+        tx_current_map_a={14.0: 5e-3},
+    )
+
+
+def make_node(profile: EnergyProfile) -> Node:
+    ch = Channel()
+    return Node(0, 0.0, 0.0, sf=7, tx_power=14.0, channel=ch, energy_profile=profile)
+
+
+def test_sleep_energy_enforced(energy_profile: EnergyProfile) -> None:
+    node = make_node(energy_profile)
+    node.add_energy(0.0, "sleep", duration_s=2.0)
+    expected = energy_profile.energy_for("sleep", 2.0)
+    assert node.energy_sleep == pytest.approx(expected)
+    assert node.energy_consumed == pytest.approx(expected)
+
+
+def test_rx_energy_enforced(energy_profile: EnergyProfile) -> None:
+    node = make_node(energy_profile)
+    node.add_energy(1.0, "rx", duration_s=1.5)
+    expected = energy_profile.energy_for("rx", 1.5)
+    assert node.energy_rx == pytest.approx(expected)
+    assert node.energy_consumed == pytest.approx(expected)
+
+
+def test_tx_energy_enforced(energy_profile: EnergyProfile) -> None:
+    profile = energy_profile
+    profile = EnergyProfile(
+        voltage_v=3.0,
+        sleep_current_a=profile.sleep_current_a,
+        rx_current_a=profile.rx_current_a,
+        listen_current_a=profile.listen_current_a,
+        process_current_a=profile.process_current_a,
+        ramp_up_s=0.001,
+        ramp_down_s=0.001,
+        tx_current_map_a=profile.tx_current_map_a,
+    )
+    node = make_node(profile)
+    node.add_energy(0.0, "tx", duration_s=0.5)
+    tx = profile.energy_for("tx", 0.5, power_dBm=14.0)
+    ramp = profile.energy_for("ramp", profile.ramp_up_s + profile.ramp_down_s, power_dBm=14.0)
+    assert node.energy_tx == pytest.approx(tx)
+    assert node.energy_ramp == pytest.approx(ramp)
+    assert node.energy_consumed == pytest.approx(tx + ramp)


### PR DESCRIPTION
## Summary
- enforce E=V·I·t conservation by normalising node energy accounting and propagating ramp/startup adjustments into simulator totals
- add automated energy conservation tests and a CLI benchmark that exports per-state totals for LoRaWAN classes A/B/C
- document the updated energy profile workflow and reference the new benchmark utility in the README

## Testing
- pytest tests/test_energy_conservation.py tests/test_flora_energy.py tests/test_energy_accounting.py tests/test_benchmark_energy_classes.py

------
https://chatgpt.com/codex/tasks/task_e_68d57e12396483319f3ec1a532824250