### PR TITLE
Improve SER fallback and downlink scheduling

### DIFF
--- a/docs/lorawan_features.md
+++ b/docs/lorawan_features.md
@@ -43,6 +43,9 @@ Ce document résume les différences entre la simulation FLoRa d'origine
 
 - Sécurité LoRaWAN (chiffrement des charges utiles et MIC).
 - Gestion explicite des classes B et C avec planification des downlinks.
+- Sélection du data rate downlink conforme aux paramètres régionaux LoRaWAN
+  (formule EU868/IN865/KR920/AS923, tables US/AU915) validée par les tests
+  automatisés.【F:loraflexsim/launcher/lorawan.py†L12-L71】【F:tests/test_downlink_dr.py†L1-L23】
 - Grand nombre de commandes MAC supplémentaires.
 - Activation OTAA avec dérivation dynamique des clés.
 

--- a/flora-master/src/LoRaPhy/LoRaModulation.cc
+++ b/flora-master/src/LoRaPhy/LoRaModulation.cc
@@ -13,6 +13,8 @@
 // along with this program.  If not, see http://www.gnu.org/licenses/.
 // 
 
+#include <cmath>
+
 #include "LoRaModulation.h"
 
 namespace flora {
@@ -73,8 +75,23 @@ double LoRaModulation::calculateBER(double snir, Hz bandwidth, bps bitrate) cons
 
 double LoRaModulation::calculateSER(double snir, Hz bandwidth, bps bitrate) const
 {
-    return NaN;
-//    throw cRuntimeError("Not yet implemented");
+    double ber = calculateBER(snir, bandwidth, bitrate);
+    if (!std::isfinite(ber))
+        return 1.0;
+    if (ber <= 0.0)
+        return 0.0;
+    if (ber >= 1.0)
+        return 1.0;
+
+    const double bitsPerSymbol = spreadFactor > 0 ? static_cast<double>(spreadFactor) : 1.0;
+    double ser = 1.0 - std::pow(1.0 - ber, bitsPerSymbol);
+    if (!std::isfinite(ser))
+        ser = 1.0;
+    else if (ser < 0.0)
+        ser = 0.0;
+    else if (ser > 1.0)
+        ser = 1.0;
+    return ser;
 }
 
 } // namespace inet

--- a/loraflexsim/launcher/channel.py
+++ b/loraflexsim/launcher/channel.py
@@ -856,10 +856,17 @@ class Channel:
         gain = max(math.cos(angle_rad), 0.0) ** 2
         return 10 * math.log10(max(gain, 1e-3))
 
-    def airtime(self, sf: int, payload_size: int = 20) -> float:
+    def airtime(
+        self,
+        sf: int,
+        payload_size: int = 20,
+        *,
+        bandwidth: float | None = None,
+    ) -> float:
         """Calcule l'airtime complet d'un paquet LoRa en secondes."""
         # Durée d'un symbole
-        rs = self.bandwidth / (2 ** sf)
+        bw = self.bandwidth if bandwidth is None else bandwidth
+        rs = bw / (2 ** sf)
         ts = 1.0 / rs
         de = 1 if sf >= self.low_data_rate_threshold else 0
         cr_denom = self.coding_rate + 4

--- a/tests/test_class_bc.py
+++ b/tests/test_class_bc.py
@@ -33,6 +33,36 @@ def test_schedule_class_b():
     assert frame == b"a" and gw2 is gw
 
 
+def test_schedule_class_b_replans_busy_slot():
+    scheduler = DownlinkScheduler()
+    gw = Gateway(1, 0, 0)
+    node = Node(1, 0.0, 0.0, 7, 14, class_type="B")
+    first = scheduler.schedule_class_b(
+        node,
+        0.0,
+        b"a",
+        gw,
+        beacon_interval=128.0,
+        ping_slot_interval=1.0,
+        ping_slot_offset=2.0,
+    )
+    second = scheduler.schedule_class_b(
+        node,
+        0.0,
+        b"b",
+        gw,
+        beacon_interval=128.0,
+        ping_slot_interval=1.0,
+        ping_slot_offset=2.0,
+    )
+    assert math.isclose(first, 2.0)
+    assert math.isclose(second, 3.0)
+    frame1, gw1 = scheduler.pop_ready(node.id, first)
+    frame2, gw2 = scheduler.pop_ready(node.id, second)
+    assert frame1 == b"a" and gw1 is gw
+    assert frame2 == b"b" and gw2 is gw
+
+
 def test_schedule_class_c_delay():
     scheduler = DownlinkScheduler(link_delay=0.5)
     gw = Gateway(1, 0, 0)

--- a/tests/test_downlink_dr.py
+++ b/tests/test_downlink_dr.py
@@ -1,0 +1,20 @@
+from loraflexsim.launcher.lorawan import DOWNLINK_DR_TO_SF, rx1_downlink_dr
+
+
+def test_rx1_downlink_eu868():
+    assert rx1_downlink_dr("EU868", uplink_dr=5, rx1_dr_offset=2) == 3
+
+
+def test_rx1_downlink_us915_table():
+    assert rx1_downlink_dr("US915", uplink_dr=0, rx1_dr_offset=0) == 10
+    assert rx1_downlink_dr("US915", uplink_dr=3, rx1_dr_offset=3) == 10
+    assert rx1_downlink_dr("US915", uplink_dr=4, rx1_dr_offset=7) == 8
+
+
+def test_rx1_downlink_unknown_region_defaults():
+    assert rx1_downlink_dr("UNKNOWN", uplink_dr=2, rx1_dr_offset=5) == 0
+
+
+def test_downlink_dr_to_sf_extends_mapping():
+    assert DOWNLINK_DR_TO_SF[10] == 10
+    assert DOWNLINK_DR_TO_SF[13] == 7


### PR DESCRIPTION
## Summary
- Compute a bounded SER value from the BER to avoid NaN returns in the FLoRa modulation model
- Rework Class B downlink scheduling to respect ping-slot cadence when gateways are busy and extend airtime calculations for custom bandwidths
- Model RX1 downlink data-rate selection per LoRaWAN region (with documentation and tests) and adjust simulator energy accounting accordingly

## Testing
- pytest tests/test_class_bc.py tests/test_downlink_dr.py

------
https://chatgpt.com/codex/tasks/task_e_68d57e35cbec83319c64079bdf728ffc