### PR TITLE
Add duty cycle energy plots to article A batch runner

### DIFF
--- a/scripts/mne3sd/run_all_article_outputs.py
+++ b/scripts/mne3sd/run_all_article_outputs.py
@@ -74,6 +74,14 @@ ARTICLE_PLOTS: dict[str, tuple[Task, ...]] = {
                 Path("figures/mne3sd/article_a/class_pdr_vs_interval.eps"),
             ),
         ),
+        Task(
+            module="scripts.mne3sd.article_a.plots.plot_energy_duty_cycle",
+            description="Energy consumption versus duty cycle plots",
+            outputs=(
+                Path("figures/mne3sd/article_a/energy_per_node_vs_duty_cycle.png"),
+                Path("figures/mne3sd/article_a/energy_per_node_vs_duty_cycle.eps"),
+            ),
+        ),
     ),
     "b": (
         Task(


### PR DESCRIPTION
## Summary
- add the energy-versus-duty-cycle plotting task to the article A batch pipeline
- register the PNG/EPS artefacts so the generated figures appear in the final summary

## Testing
- `python -m scripts.mne3sd.run_all_article_outputs --article a --skip-scenarios` *(fails: missing local input CSV for class load plot)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d825c714833198536ae2c7b302cd