### PR TITLE
Documenter la commande de cycle énergétique

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,6 +937,7 @@ python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv -
 python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv --scenarios n50_c1_static n50_c1_mobile
 python scripts/plot_mobility_latency_energy.py results/mobility_latency_energy.csv
 python scripts/benchmark_energy_classes.py --nodes 20 --packets 5 --output results/energy_classes.csv
+python -m scripts.mne3sd.article_a.plots.plot_energy_duty_cycle --results results/mne3sd/article_a
 ```
 
 `plot_sf_distribution.py` generates `sf_distribution` in PNG, JPG and EPS,
@@ -955,6 +956,11 @@ vector graphics.
 B et C) et exporte un fichier CSV contenant la consommation totale et la
 décomposition TX/RX/veille, ce qui permet de comparer rapidement les profils
 énergétiques.
+
+La commande `plot_energy_duty_cycle` est détaillée dans la documentation
+[« Profils énergétiques »](docs/energy_profiles.md#visualisation-du-cycle-dactivité-énergétique)
+et produit automatiquement un résumé (`results/.../energy_consumption_summary.csv`)
+et les figures associées (`figures/.../*.png`, `figures/.../*.eps`).
 
 ## Calcul de l'airtime
 

--- a/docs/energy_profiles.md
+++ b/docs/energy_profiles.md
@@ -47,3 +47,29 @@ python scripts/benchmark_energy_classes.py --nodes 20 --packets 5 --output resul
 
 Le fichier généré peut ensuite être tracé avec un tableur ou un outil dédié
 afin de documenter et comparer les profils de consommation.
+
+## Visualisation du cycle d'activité énergétique
+
+Pour analyser la consommation issue des scénarios de l'article A, le module
+[`scripts.mne3sd.article_a.plots.plot_energy_duty_cycle`](../scripts/mne3sd/article_a/plots/plot_energy_duty_cycle.py)
+propose une commande prête à l'emploi :
+
+```bash
+python -m scripts.mne3sd.article_a.plots.plot_energy_duty_cycle --results results/mne3sd/article_a
+```
+
+Cette commande charge le résumé énergétique généré par les simulations
+(`results/.../energy_consumption_summary.csv`) et produit plusieurs figures
+comparant le cycle d'activité des nœuds.  Les graphiques exportés se trouvent
+dans `figures/.../` au format PNG et EPS (par exemple
+`figures/.../energy_duty_cycle.png` et `figures/.../energy_duty_cycle.eps`).
+
+Les options principales permettent de :
+
+- préciser la source des données via `--results` ;
+- activer la génération d'un rendu LaTeX (`--latex`) ;
+- afficher les figures à l'écran (`--show`).
+
+La commande fonctionne également sous Windows 11 (fenêtre **cmd**) en adaptant
+les chemins (`python -m ...`).  Elle facilite ainsi la traçabilité des
+consommations mesurées dans l'étude.


### PR DESCRIPTION
## Summary
- décrire dans la documentation énergétique la commande python -m scripts.mne3sd.article_a.plots.plot_energy_duty_cycle et ses sorties
- ajouter dans le README un lien direct vers la section détaillant la commande et ses fichiers générés

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5d829bd6c8331a9227e64c46d90f6