### PR TITLE
Ajoute un seuil d'énergie FLoRa

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ les paramètres suivants sont appliqués lors de la création du `Simulator` ou 
 - `use_flora_curves=True` — charge les équations de perte et de PER de FLoRa.
   Ce paramètre est forcé par `flora_mode`, mais peut être activé manuellement
   lorsque seul le canal doit reproduire les courbes historiques.【F:loraflexsim/launcher/simulator.py†L354-L384】
-- `detection_threshold_dBm=-110` — valeur par défaut des scénarios FLoRa ; elle
-  est propagée à tous les canaux lorsque `flora_mode` est actif, avec un
-  fallback de `-110` dBm si une combinaison SF/BW n'est pas définie par la table
-  d'origine.【F:loraflexsim/launcher/simulator.py†L373-L385】【F:loraflexsim/launcher/channel.py†L93-L114】
+- `detection_threshold_dBm=-110` et `energy_detection_dBm=-90` — valeurs par
+  défaut des scénarios FLoRa ; elles sont propagées à tous les canaux et
+  passerelles lorsque `flora_mode` est actif, avec un fallback de `-110` dBm si
+  une combinaison SF/BW n'est pas définie par la table d'origine.【F:loraflexsim/launcher/simulator.py†L354-L470】【F:loraflexsim/launcher/channel.py†L68-L204】
 - **Presets de propagation** — utilisez `environment="flora"`, `"flora_hata"`
   ou `"flora_oulu"` pour sélectionner respectivement la perte log-normale, la
   variante Hata-Okumura ou le modèle Oulu reproduits depuis FLoRa. Ces presets

--- a/docs/reproduction_flora.md
+++ b/docs/reproduction_flora.md
@@ -12,7 +12,7 @@ Ce guide rassemble les réglages indispensables pour aligner un scénario LoRaFl
 
 Activez systématiquement les options suivantes sur le constructeur `Simulator` :
 
-- `flora_mode=True` : applique automatiquement le modèle physique `omnet_full`, charge la matrice de collisions non orthogonales, force le shadowing log-normal de FLoRa et verrouille le seuil de détection à `-110 dBm` sur tous les canaux.【F:loraflexsim/launcher/simulator.py†L354-L470】【F:loraflexsim/launcher/channel.py†L454-L520】
+- `flora_mode=True` : applique automatiquement le modèle physique `omnet_full`, charge la matrice de collisions non orthogonales, force le shadowing log-normal de FLoRa et verrouille les seuils radio (`detection_threshold_dBm=-110`, `energy_detection_dBm=-90`) sur tous les canaux et passerelles.【F:loraflexsim/launcher/simulator.py†L354-L575】【F:loraflexsim/launcher/channel.py†L454-L560】
 - `flora_timing=True` : aligne les temporisations MAC (RX1/RX2, latence serveur, traitement réseau) sur celles d'OMNeT++ pour garantir des fenêtres descendantes identiques.【F:loraflexsim/launcher/simulator.py†L231-L388】【F:loraflexsim/launcher/server.py†L72-L321】
 - `adr_method="avg"` : reproduit la stratégie ADR historique basée sur la moyenne glissante des 20 derniers SNR remontés par chaque nœud.【F:loraflexsim/launcher/server.py†L216-L321】【F:tests/test_flora_sca.py†L18-L39】
 - `phy_model="flora"` ou `"flora_cpp"` (si la bibliothèque native est compilée) : garantit l'utilisation des équations de PER et du comportement de capture exacts du code C++.【F:loraflexsim/launcher/simulator.py†L446-L575】【F:README.md†L582-L662】

--- a/loraflexsim/launcher/server.py
+++ b/loraflexsim/launcher/server.py
@@ -35,6 +35,7 @@ class NetworkServer:
         process_delay: float = 0.0,
         network_delay: float = 0.0,
         adr_method: str = "max",
+        energy_detection_dBm: float = -float("inf"),
     ):
         """Initialise le serveur réseau.
 
@@ -45,6 +46,9 @@ class NetworkServer:
         :param network_delay: Délai de propagation des messages (s).
         :param adr_method: Méthode d'agrégation du SNR pour l'ADR
             (``"max"`` ou ``"avg"``).
+        :param energy_detection_dBm: Seuil de détection d'énergie appliqué aux
+            configurations FLoRa (−90 dBm par défaut lorsque fourni par le
+            simulateur).
         """
         # Ensemble des identifiants d'événements déjà reçus (pour éviter les doublons)
         self.received_events = set()
@@ -70,6 +74,7 @@ class NetworkServer:
         self.process_delay = process_delay
         self.network_delay = network_delay
         self.adr_method = adr_method
+        self.energy_detection_dBm = energy_detection_dBm
         self.pending_process: dict[
             int,
             tuple[int, int, int, float | None, float | None, object, float | None],

--- a/tests/test_flora_defaults.py
+++ b/tests/test_flora_defaults.py
@@ -1,5 +1,6 @@
 """Tests ensuring FLoRa configurations use the non-orthogonal capture matrix by default."""
 
+from loraflexsim.launcher.channel import Channel
 from loraflexsim.launcher.gateway import FLORA_NON_ORTH_DELTA
 from loraflexsim.launcher.simulator import Simulator
 
@@ -21,7 +22,66 @@ def test_flora_simulator_uses_non_orthogonal_capture():
     # The main channel and all nodes should immediately use the FLoRa matrix
     assert sim.channel.orthogonal_sf is False
     assert sim.channel.non_orth_delta == FLORA_NON_ORTH_DELTA
+    assert sim.channel.energy_detection_dBm == Channel.FLORA_ENERGY_DETECTION_DBM
 
     node = sim.nodes[0]
     assert node.channel.orthogonal_sf is False
     assert node.channel.non_orth_delta == FLORA_NON_ORTH_DELTA
+    assert node.channel.energy_detection_dBm == Channel.FLORA_ENERGY_DETECTION_DBM
+
+    gw = sim.gateways[0]
+    assert gw.energy_detection_dBm == Channel.FLORA_ENERGY_DETECTION_DBM
+    assert sim.network_server.energy_detection_dBm == Channel.FLORA_ENERGY_DETECTION_DBM
+
+
+def test_flora_energy_detection_filters_frames():
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        flora_mode=True,
+        phy_model="omnet_full",
+        packets_to_send=1,
+        mobility=False,
+        duty_cycle=None,
+        warm_up_intervals=0,
+        log_mean_after=None,
+        seed=42,
+    )
+
+    node = sim.nodes[0]
+    gateway = sim.gateways[0]
+
+    assert node.channel.energy_detection_dBm == Channel.FLORA_ENERGY_DETECTION_DBM
+    assert gateway.energy_detection_dBm == Channel.FLORA_ENERGY_DETECTION_DBM
+
+    add_called = False
+    start_called = False
+
+    def fake_add(*args, **kwargs):
+        nonlocal add_called
+        add_called = True
+
+    def fake_start(*args, **kwargs):
+        nonlocal start_called
+        start_called = True
+
+    def fake_average_power(
+        gateway_id, frequency, current_time, end_time, *, base_noise_mW=0.0
+    ) -> float:
+        return base_noise_mW
+
+    def fake_compute_rssi(tx_power, distance, sf, **kwargs):
+        node.channel.last_noise_dBm = -100.0
+        return -95.0, -5.0
+
+    sim._tx_manager.add = fake_add
+    sim._tx_manager.average_power = fake_average_power
+    gateway.start_reception = fake_start
+    node.channel.compute_rssi = fake_compute_rssi
+
+    sim.run(max_steps=10)
+    sim.stop()
+
+    assert not add_called
+    assert not start_called
+    assert node.last_rssi is None


### PR DESCRIPTION
## Résumé
- ajoute un attribut `energy_detection_dBm` aux canaux, passerelles et serveur pour appliquer automatiquement le seuil FLoRa de −90 dBm
- fait respecter ce seuil dans la planification des transmissions et dans `Gateway.start_reception`
- étend les tests FLoRa et la documentation pour couvrir le nouveau comportement

## Tests
- `pytest tests/test_flora_defaults.py`


------
https://chatgpt.com/codex/tasks/task_e_68d5dd8b169083319f440059b6b1f994