### PR TITLE
Ajoute pipeline CI modulaire et cible de validation

### DIFF
--- a/.github/workflows/test-groups.yml
+++ b/.github/workflows/test-groups.yml
@@ -1,0 +1,128 @@
+name: Tests ciblés
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+
+jobs:
+  channel:
+    name: Canal
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Installer les dépendances
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+          pip install pytest
+      - name: Tests canal
+        run: pytest -k "channel"
+
+  phy:
+    name: PHY
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Installer les dépendances
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+          pip install pytest
+      - name: Tests PHY
+        run: pytest -k "omnet_phy or rx_chain or overlap_snir or flora_capture or startup_currents or pa_ramp"
+
+  gateway:
+    name: Passerelle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Installer les dépendances
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+          pip install pytest
+      - name: Tests passerelle
+        run: pytest -k "gateway or collision_capture or compare_flora"
+
+  server:
+    name: Serveur réseau
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Installer les dépendances
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+          pip install pytest
+      - name: Tests serveur
+        run: pytest -k "network_server or no_random_drop or run_simulate or class_bc"
+
+  lorawan:
+    name: LoRaWAN
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Installer les dépendances
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+          pip install pytest
+      - name: Tests LoRaWAN
+        run: pytest -k "lorawan or class_a or rx_windows or adr or flora_energy"
+
+  mobility:
+    name: Mobilité
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Installer les dépendances
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+          pip install pytest
+      - name: Tests mobilité
+        run: pytest -k "mobility"
+
+  api:
+    name: API
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Installer les dépendances
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+          pip install pytest
+      - name: Tests API
+        run: pytest -k "rest_api or web_api"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: validate
+
+validate:
+	pytest -k "channel"
+	pytest -k "omnet_phy or rx_chain or overlap_snir or flora_capture or startup_currents or pa_ramp"
+	pytest -k "gateway or collision_capture or compare_flora"
+	pytest -k "network_server or no_random_drop or run_simulate or class_bc"
+	pytest -k "lorawan or class_a or rx_windows or adr or flora_energy"
+	pytest -k "mobility"
+	pytest -k "rest_api or web_api"
+	python scripts/run_validation.py

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ sensibilité. Un chemin personnalisé peut être fourni via `flora_noise_path`.
    > ``numpy_stub`` situé dans ``tests/stubs`` uniquement pour les tests. Pour
    > exécuter les scripts ou les exemples de LoRaFlexSim, assurez‑vous que la
    > véritable bibliothèque NumPy est installée dans votre environnement.
+
+## ✅ Vérification avant mise à jour
+
+Avant de mettre à jour votre branche ou de soumettre une contribution,
+exécutez la commande suivante depuis la racine du dépôt :
+
+```bash
+make validate
+```
+
+Cette cible `make` enchaîne les suites de tests par domaine (`-k channel`,
+`-k class_bc`, etc.) puis lance `scripts/run_validation.py` afin de garantir
+qu'aucune régression n'a été introduite. Sur Windows, exécutez cette commande
+depuis un terminal disposant de `make` (Git Bash, WSL ou équivalent).
 3. **Lancez le tableau de bord :**
 ```bash
 panel serve loraflexsim/launcher/dashboard.py --show


### PR DESCRIPTION
## Résumé
- ajouter un workflow GitHub Actions dédié à chaque domaine de tests (canal, PHY, passerelle, serveur, LoRaWAN, mobilité, API)
- introduire la cible `make validate` qui rejoue les suites `pytest` par groupe puis exécute `scripts/run_validation.py`
- documenter dans le README la commande à lancer avant une mise à jour

## Tests
- make validate *(échoue sur `scripts/run_validation.py` faute de métriques de référence disponibles dans l'environnement CI)*
- pytest -k "rest_api or web_api" -q


------
https://chatgpt.com/codex/tasks/task_e_68d5f4b1cd188331a97946fad1129969