### PR TITLE
Organiser la hiérarchie des figures MNE3SD

### DIFF
--- a/scripts/mne3sd/article_a/plots/plot_class_load_results.py
+++ b/scripts/mne3sd/article_a/plots/plot_class_load_results.py
@@ -13,10 +13,15 @@ import pandas as pd
 ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, os.fspath(ROOT))
 
-from scripts.mne3sd.common import apply_ieee_style, save_figure
+from scripts.mne3sd.common import (
+    apply_ieee_style,
+    prepare_figure_directory,
+    save_figure,
+)
 
 RESULTS_PATH = ROOT / "results" / "mne3sd" / "article_a" / "class_load_metrics.csv"
-FIGURES_DIR = ROOT / "figures" / "mne3sd" / "article_a"
+ARTICLE = "article_a"
+SCENARIO = "class_load"
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -64,7 +69,7 @@ def load_metrics(path: Path) -> pd.DataFrame:
     return df
 
 
-def plot_energy_by_interval(df: pd.DataFrame, output_dir: Path) -> None:
+def plot_energy_by_interval(df: pd.DataFrame) -> None:
     """Plot the average per-node energy versus interval for each class."""
     grouped = (
         df.groupby(["class", "interval_s"], as_index=False)["energy_per_node_J"].mean()
@@ -88,10 +93,15 @@ def plot_energy_by_interval(df: pd.DataFrame, output_dir: Path) -> None:
     ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.7)
     fig.tight_layout()
 
+    output_dir = prepare_figure_directory(
+        article=ARTICLE,
+        scenario=SCENARIO,
+        metric="energy_vs_interval",
+    )
     save_figure(fig, "class_energy_vs_interval", output_dir)
 
 
-def plot_pdr_by_interval(df: pd.DataFrame, output_dir: Path) -> None:
+def plot_pdr_by_interval(df: pd.DataFrame) -> None:
     """Plot the packet delivery ratio versus interval with error bars."""
     stats = (
         df.groupby(["class", "interval_s"], as_index=False)["pdr"]
@@ -123,6 +133,11 @@ def plot_pdr_by_interval(df: pd.DataFrame, output_dir: Path) -> None:
     ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.7)
     fig.tight_layout()
 
+    output_dir = prepare_figure_directory(
+        article=ARTICLE,
+        scenario=SCENARIO,
+        metric="pdr_vs_interval",
+    )
     save_figure(fig, "class_pdr_vs_interval", output_dir)
 
 
@@ -135,8 +150,8 @@ def main() -> None:
 
     metrics = load_metrics(args.results)
 
-    plot_energy_by_interval(metrics, FIGURES_DIR)
-    plot_pdr_by_interval(metrics, FIGURES_DIR)
+    plot_energy_by_interval(metrics)
+    plot_pdr_by_interval(metrics)
 
     if args.show:
         plt.show()

--- a/scripts/mne3sd/article_b/plots/plot_mobility_range_metrics.py
+++ b/scripts/mne3sd/article_b/plots/plot_mobility_range_metrics.py
@@ -13,10 +13,15 @@ import pandas as pd
 ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, os.fspath(ROOT))
 
-from scripts.mne3sd.common import apply_ieee_style, save_figure
+from scripts.mne3sd.common import (
+    apply_ieee_style,
+    prepare_figure_directory,
+    save_figure,
+)
 
 RESULTS_PATH = ROOT / "results" / "mne3sd" / "article_b" / "mobility_range_metrics.csv"
-FIGURES_DIR = ROOT / "figures" / "mne3sd" / "article_b"
+ARTICLE = "article_b"
+SCENARIO = "mobility_range"
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -90,7 +95,7 @@ def load_metrics(path: Path) -> pd.DataFrame:
 
 
 def plot_pdr_vs_range(
-    df: pd.DataFrame, output_dir: Path, highlight_threshold: float | None
+    df: pd.DataFrame, highlight_threshold: float | None
 ) -> None:
     """Plot aggregated PDR versus communication range with error bars."""
 
@@ -134,10 +139,15 @@ def plot_pdr_vs_range(
     ax.legend()
     fig.tight_layout()
 
+    output_dir = prepare_figure_directory(
+        article=ARTICLE,
+        scenario=SCENARIO,
+        metric="pdr_vs_range",
+    )
     save_figure(fig, "pdr_vs_communication_range", output_dir)
 
 
-def plot_delay_vs_range(df: pd.DataFrame, output_dir: Path) -> None:
+def plot_delay_vs_range(df: pd.DataFrame) -> None:
     """Plot aggregated average delay versus communication range."""
 
     fig, ax = plt.subplots()
@@ -158,6 +168,11 @@ def plot_delay_vs_range(df: pd.DataFrame, output_dir: Path) -> None:
     ax.legend()
     fig.tight_layout()
 
+    output_dir = prepare_figure_directory(
+        article=ARTICLE,
+        scenario=SCENARIO,
+        metric="average_delay_vs_range",
+    )
     save_figure(fig, "average_delay_vs_communication_range", output_dir)
 
 
@@ -170,8 +185,8 @@ def main() -> None:  # pragma: no cover - CLI entry point
 
     metrics = load_metrics(args.results)
 
-    plot_pdr_vs_range(metrics, FIGURES_DIR, args.highlight_threshold)
-    plot_delay_vs_range(metrics, FIGURES_DIR)
+    plot_pdr_vs_range(metrics, args.highlight_threshold)
+    plot_delay_vs_range(metrics)
 
     if args.show:
         plt.show()

--- a/scripts/mne3sd/article_b/plots/plot_mobility_speed_metrics.py
+++ b/scripts/mne3sd/article_b/plots/plot_mobility_speed_metrics.py
@@ -15,10 +15,15 @@ import pandas as pd
 ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, os.fspath(ROOT))
 
-from scripts.mne3sd.common import apply_ieee_style, save_figure
+from scripts.mne3sd.common import (
+    apply_ieee_style,
+    prepare_figure_directory,
+    save_figure,
+)
 
 RESULTS_PATH = ROOT / "results" / "mne3sd" / "article_b" / "mobility_speed_metrics.csv"
-FIGURES_DIR = ROOT / "figures" / "mne3sd" / "article_b"
+ARTICLE = "article_b"
+SCENARIO = "mobility_speed"
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -152,7 +157,6 @@ def plot_grouped_bars(
     ylabel: str,
     title: str,
     output_name: str,
-    output_dir: Path,
     dpi: int,
     value_format: str,
     ylim: tuple[float, float] | None = None,
@@ -186,11 +190,16 @@ def plot_grouped_bars(
         ax.bar_label(container, fmt=value_format, padding=2, fontsize=7)
 
     fig.tight_layout()
+    output_dir = prepare_figure_directory(
+        article=ARTICLE,
+        scenario=SCENARIO,
+        metric=output_name,
+    )
     save_figure(fig, output_name, output_dir, dpi=dpi)
     plt.close(fig)
 
 
-def plot_heatmap(df: pd.DataFrame, output_name: str, output_dir: Path, dpi: int) -> None:
+def plot_heatmap(df: pd.DataFrame, output_name: str, dpi: int) -> None:
     """Plot a heatmap of PDR versus communication range when available."""
 
     if "range_km" not in df.columns:
@@ -238,6 +247,11 @@ def plot_heatmap(df: pd.DataFrame, output_name: str, output_dir: Path, dpi: int)
     cbar.set_label("PDR (%)")
 
     fig.tight_layout()
+    output_dir = prepare_figure_directory(
+        article=ARTICLE,
+        scenario=SCENARIO,
+        metric=output_name,
+    )
     save_figure(fig, output_name, output_dir, dpi=dpi)
     plt.close(fig)
 
@@ -262,7 +276,6 @@ def main() -> None:  # pragma: no cover - CLI entry point
         pdr_label,
         "PDR by speed profile",
         "pdr_by_speed_profile",
-        FIGURES_DIR,
         args.dpi,
         pdr_format,
         ylim=pdr_ylim,
@@ -274,7 +287,6 @@ def main() -> None:  # pragma: no cover - CLI entry point
         "Average delay (s)",
         "Average delay by speed profile",
         "average_delay_by_speed_profile",
-        FIGURES_DIR,
         args.dpi,
         "{:.2f}",
     )
@@ -282,7 +294,6 @@ def main() -> None:  # pragma: no cover - CLI entry point
     plot_heatmap(
         metrics,
         "pdr_heatmap_speed_profile_range",
-        FIGURES_DIR,
         args.dpi,
     )
 

--- a/scripts/mne3sd/common.py
+++ b/scripts/mne3sd/common.py
@@ -32,6 +32,29 @@ def ensure_directory(path: str | Path) -> Path:
     return directory
 
 
+def prepare_figure_directory(
+    *,
+    article: str,
+    scenario: str,
+    metric: str,
+    base_dir: str | Path | None = None,
+) -> Path:
+    """Return the output directory for the given article/scenario/metric trio."""
+
+    components = {"article": article, "scenario": scenario, "metric": metric}
+    missing = [name for name, value in components.items() if not value]
+    if missing:
+        joined = ", ".join(missing)
+        raise ValueError(f"Missing figure directory component(s): {joined}")
+
+    if base_dir is None:
+        base_path = Path(__file__).resolve().parents[2] / "figures" / "mne3sd"
+    else:
+        base_path = Path(base_dir)
+
+    return ensure_directory(base_path / article / scenario / metric)
+
+
 def apply_ieee_style(figsize: tuple[float, float] = (3.5, 2.2)) -> None:
     """Apply a compact IEEE-friendly Matplotlib style."""
 

--- a/scripts/mne3sd/run_all_article_outputs.py
+++ b/scripts/mne3sd/run_all_article_outputs.py
@@ -68,18 +68,56 @@ ARTICLE_PLOTS: dict[str, tuple[Task, ...]] = {
             module="scripts.mne3sd.article_a.plots.plot_class_load_results",
             description="Class load plots",
             outputs=(
-                Path("figures/mne3sd/article_a/class_energy_vs_interval.png"),
-                Path("figures/mne3sd/article_a/class_energy_vs_interval.eps"),
-                Path("figures/mne3sd/article_a/class_pdr_vs_interval.png"),
-                Path("figures/mne3sd/article_a/class_pdr_vs_interval.eps"),
+                Path(
+                    "figures/mne3sd/article_a/class_load/energy_vs_interval/"
+                    "class_energy_vs_interval.png"
+                ),
+                Path(
+                    "figures/mne3sd/article_a/class_load/energy_vs_interval/"
+                    "class_energy_vs_interval.eps"
+                ),
+                Path(
+                    "figures/mne3sd/article_a/class_load/pdr_vs_interval/"
+                    "class_pdr_vs_interval.png"
+                ),
+                Path(
+                    "figures/mne3sd/article_a/class_load/pdr_vs_interval/"
+                    "class_pdr_vs_interval.eps"
+                ),
             ),
         ),
         Task(
             module="scripts.mne3sd.article_a.plots.plot_energy_duty_cycle",
             description="Energy consumption versus duty cycle plots",
             outputs=(
-                Path("figures/mne3sd/article_a/energy_per_node_vs_duty_cycle.png"),
-                Path("figures/mne3sd/article_a/energy_per_node_vs_duty_cycle.eps"),
+                Path(
+                    "figures/mne3sd/article_a/energy_duty_cycle/"
+                    "energy_per_node_vs_duty_cycle/"
+                    "energy_per_node_vs_duty_cycle.png"
+                ),
+                Path(
+                    "figures/mne3sd/article_a/energy_duty_cycle/"
+                    "energy_per_node_vs_duty_cycle/"
+                    "energy_per_node_vs_duty_cycle.eps"
+                ),
+                Path(
+                    "figures/mne3sd/article_a/energy_duty_cycle/pdr_vs_duty_cycle/"
+                    "pdr_vs_duty_cycle.png"
+                ),
+                Path(
+                    "figures/mne3sd/article_a/energy_duty_cycle/pdr_vs_duty_cycle/"
+                    "pdr_vs_duty_cycle.eps"
+                ),
+                Path(
+                    "figures/mne3sd/article_a/energy_duty_cycle/"
+                    "energy_breakdown_vs_duty_cycle/"
+                    "energy_breakdown_vs_duty_cycle.png"
+                ),
+                Path(
+                    "figures/mne3sd/article_a/energy_duty_cycle/"
+                    "energy_breakdown_vs_duty_cycle/"
+                    "energy_breakdown_vs_duty_cycle.eps"
+                ),
             ),
         ),
     ),
@@ -89,16 +127,20 @@ ARTICLE_PLOTS: dict[str, tuple[Task, ...]] = {
             description="Mobility range plots",
             outputs=(
                 Path(
-                    "figures/mne3sd/article_b/pdr_vs_communication_range.png"
+                    "figures/mne3sd/article_b/mobility_range/pdr_vs_range/"
+                    "pdr_vs_communication_range.png"
                 ),
                 Path(
-                    "figures/mne3sd/article_b/pdr_vs_communication_range.eps"
+                    "figures/mne3sd/article_b/mobility_range/pdr_vs_range/"
+                    "pdr_vs_communication_range.eps"
                 ),
                 Path(
-                    "figures/mne3sd/article_b/average_delay_vs_communication_range.png"
+                    "figures/mne3sd/article_b/mobility_range/average_delay_vs_range/"
+                    "average_delay_vs_communication_range.png"
                 ),
                 Path(
-                    "figures/mne3sd/article_b/average_delay_vs_communication_range.eps"
+                    "figures/mne3sd/article_b/mobility_range/average_delay_vs_range/"
+                    "average_delay_vs_communication_range.eps"
                 ),
             ),
         ),
@@ -106,15 +148,33 @@ ARTICLE_PLOTS: dict[str, tuple[Task, ...]] = {
             module="scripts.mne3sd.article_b.plots.plot_mobility_speed_metrics",
             description="Mobility speed plots",
             outputs=(
-                Path("figures/mne3sd/article_b/pdr_by_speed_profile.png"),
-                Path("figures/mne3sd/article_b/pdr_by_speed_profile.eps"),
-                Path("figures/mne3sd/article_b/average_delay_by_speed_profile.png"),
-                Path("figures/mne3sd/article_b/average_delay_by_speed_profile.eps"),
                 Path(
-                    "figures/mne3sd/article_b/pdr_heatmap_speed_profile_range.png"
+                    "figures/mne3sd/article_b/mobility_speed/pdr_by_speed_profile/"
+                    "pdr_by_speed_profile.png"
                 ),
                 Path(
-                    "figures/mne3sd/article_b/pdr_heatmap_speed_profile_range.eps"
+                    "figures/mne3sd/article_b/mobility_speed/pdr_by_speed_profile/"
+                    "pdr_by_speed_profile.eps"
+                ),
+                Path(
+                    "figures/mne3sd/article_b/mobility_speed/"
+                    "average_delay_by_speed_profile/"
+                    "average_delay_by_speed_profile.png"
+                ),
+                Path(
+                    "figures/mne3sd/article_b/mobility_speed/"
+                    "average_delay_by_speed_profile/"
+                    "average_delay_by_speed_profile.eps"
+                ),
+                Path(
+                    "figures/mne3sd/article_b/mobility_speed/"
+                    "pdr_heatmap_speed_profile_range/"
+                    "pdr_heatmap_speed_profile_range.png"
+                ),
+                Path(
+                    "figures/mne3sd/article_b/mobility_speed/"
+                    "pdr_heatmap_speed_profile_range/"
+                    "pdr_heatmap_speed_profile_range.eps"
                 ),
             ),
         ),


### PR DESCRIPTION
## Résumé
- ajoute un utilitaire `prepare_figure_directory` qui garantit la structure `figures/mne3sd/<article>/<scenario>/<metric>` avant chaque sauvegarde
- met à jour les scripts de génération de figures pour créer les sous-répertoires de scénario et de métrique et y déposer les exports PNG/EPS
- adapte `run_all_article_outputs.py` afin que le récapitulatif des artefacts pointe vers les nouveaux emplacements

## Tests
- python -m compileall scripts/mne3sd

------
https://chatgpt.com/codex/tasks/task_e_68d5f7225af48331ae4de782a105507e