### PR TITLE
Add reuse skipping logic to run_all_article_outputs

### DIFF
--- a/scripts/mne3sd/article_a/README.md
+++ b/scripts/mne3sd/article_a/README.md
@@ -85,4 +85,6 @@ python -m scripts.mne3sd.run_all_article_outputs --article a
 
 Ce script enchaîne toutes les commandes `run_class_*`, puis les modules `plot_*`, et affiche un résumé des CSV et figures générés. Utilisez `--skip-scenarios` ou `--skip-plots` pour limiter l'exécution à une seule étape, par exemple lorsque seules les figures doivent être régénérées à partir de données existantes.
 
+Lorsque vous répétez des séries de tracés, pensez à ajouter `--reuse` : les tâches dont toutes les sorties sont déjà présentes et plus récentes que le script associé seront alors ignorées, ce qui accélère significativement les itérations successives.
+
 Gardez ce README à jour au fur et à mesure que de nouveaux scénarios ou graphiques sont ajoutés afin de garantir une utilisation homogène entre collaborateur·rice·s.

--- a/scripts/mne3sd/article_b/README.md
+++ b/scripts/mne3sd/article_b/README.md
@@ -138,4 +138,6 @@ python -m scripts.mne3sd.run_all_article_outputs --article b
 
 Cette commande orchestre tous les scénarios `run_mobility_*`, puis les modules `plot_*`, et se termine en affichant la liste des CSV et figures générés. Combinez-la avec `--skip-scenarios` ou `--skip-plots` lorsque seule une partie du workflow doit être régénérée.
 
+Pour accélérer les itérations successives (par exemple lors de séries de tracés), ajoutez `--reuse` : chaque tâche vérifiera que toutes ses sorties existent et sont plus récentes que le script exécuté avant de lancer un nouveau calcul.
+
 Maintenez ce README synchronisé avec les scripts disponibles lorsque de nouveaux scénarios ou graphiques sont ajoutés.


### PR DESCRIPTION
## Summary
- add a `--reuse` flag to the article batch runner and wire it through task execution
- implement freshness checks so tasks are skipped when their artefacts are newer than the script
- document the reuse option in both article READMEs to encourage faster plotting iterations

## Testing
- python -m scripts.mne3sd.run_all_article_outputs --help


------
https://chatgpt.com/codex/tasks/task_e_68d602de32dc8331b10b329d799acc24