### PR TITLE
Add parallel execution to Article B mobility sweeps

### DIFF
--- a/scripts/mne3sd/article_b/README.md
+++ b/scripts/mne3sd/article_b/README.md
@@ -65,6 +65,9 @@ Les lanceurs de scénarios respectent l'option `--profile` partagée ainsi que l
 - `full` *(par défaut)* – exécute l'intégralité de la grille de scénarios avec les paramètres de recherche documentés.
 - `ci` – réduit le nombre de nœuds, les plages de mobilité, les permutations de passerelles et les répétitions Monte Carlo afin d'accélérer les tests automatisés tout en produisant des résultats représentatifs.
 
+### Parallélisation des réplicats
+Les scripts `run_mobility_range_sweep.py`, `run_mobility_speed_sweep.py` et `run_mobility_gateway_sweep.py` acceptent un paramètre commun `--workers` (par défaut `1`) pour répartir les réplicats Monte Carlo sur plusieurs processus. Les résultats agrégés restent triés de manière déterministe quel que soit le nombre de workers, ce qui facilite la comparaison entre exécutions. En dehors des traitements lourds, conservez la valeur par défaut pour éviter un surcoût d'initialisation. Pour des vérifications rapides sous Windows 11 ou dans un pipeline CI, combinez `--workers 1` avec `--profile ci` afin de bénéficier des paramètres allégés documentés ci-dessus.
+
 ## Structure du répertoire
 
 ```


### PR DESCRIPTION
## Summary
- parallelise the Article B mobility sweep scripts by distributing replicates with an optional ProcessPoolExecutor
- add a shared --workers argument, clamp the worker count to the number of replicates, and keep deterministic aggregation order
- document the new workers option in the Article B README along with the recommendation to pair it with --profile ci for quick checks

## Testing
- python -m compileall scripts/mne3sd/article_b/scenarios/run_mobility_range_sweep.py scripts/mne3sd/article_b/scenarios/run_mobility_speed_sweep.py scripts/mne3sd/article_b/scenarios/run_mobility_gateway_sweep.py

------
https://chatgpt.com/codex/tasks/task_e_68d602d32ddc833184c7cf4df826d402