### PR TITLE
Add shared worker auto mode for MNE3SD scenarios

### DIFF
--- a/scripts/mne3sd/article_a/scenarios/run_class_density_sweep.py
+++ b/scripts/mne3sd/article_a/scenarios/run_class_density_sweep.py
@@ -30,8 +30,10 @@ sys.path.insert(
 from loraflexsim.launcher import Simulator  # noqa: E402
 from scripts.mne3sd.common import (
     add_execution_profile_argument,
+    add_worker_argument,
     execute_simulation_tasks,
     resolve_execution_profile,
+    resolve_worker_count,
     summarise_metrics,
     write_csv,
 )
@@ -184,12 +186,7 @@ def main() -> None:  # noqa: D401 - CLI entry point
         action="store_true",
         help="Suppress progress logs (only warnings and the summary are printed)",
     )
-    parser.add_argument(
-        "--workers",
-        type=positive_int,
-        default=1,
-        help="Number of parallel worker processes to use",
-    )
+    add_worker_argument(parser)
     add_execution_profile_argument(parser)
     args = parser.parse_args()
 
@@ -233,8 +230,9 @@ def main() -> None:  # noqa: D401 - CLI entry point
                     }
                 )
 
-    if args.workers > 1:
-        LOGGER.info("Using %d worker processes", args.workers)
+    worker_count = resolve_worker_count(args.workers, len(tasks))
+    if worker_count > 1:
+        LOGGER.info("Using %d worker processes", worker_count)
 
     def log_progress(task: dict[str, object], result: dict[str, object], index: int) -> None:
         LOGGER.info(
@@ -252,8 +250,8 @@ def main() -> None:  # noqa: D401 - CLI entry point
     results = execute_simulation_tasks(
         tasks,
         run_single_simulation,
-        max_workers=args.workers,
-        progress_callback=log_progress if args.workers == 1 else None,
+        max_workers=worker_count,
+        progress_callback=log_progress if worker_count == 1 else None,
     )
 
     results.sort(key=lambda row: (row["class"], row["nodes"], row["replicate"]))

--- a/scripts/mne3sd/article_a/scenarios/simulate_energy_classes.py
+++ b/scripts/mne3sd/article_a/scenarios/simulate_energy_classes.py
@@ -39,8 +39,10 @@ sys.path.insert(
 from loraflexsim.launcher import Simulator  # noqa: E402
 from scripts.mne3sd.common import (  # noqa: E402
     add_execution_profile_argument,
+    add_worker_argument,
     execute_simulation_tasks,
     resolve_execution_profile,
+    resolve_worker_count,
     summarise_metrics,
     write_csv,
 )
@@ -259,12 +261,7 @@ def main() -> None:  # noqa: D401 - CLI entry point
         action="store_true",
         help="Enable verbose logging",
     )
-    parser.add_argument(
-        "--workers",
-        type=positive_int,
-        default=1,
-        help="Number of parallel worker processes to use",
-    )
+    add_worker_argument(parser)
     add_execution_profile_argument(parser)
     args = parser.parse_args()
 
@@ -320,8 +317,9 @@ def main() -> None:  # noqa: D401 - CLI entry point
         )
         seed_counter += 1
 
-    if args.workers > 1:
-        LOGGER.info("Using %d worker processes", args.workers)
+    worker_count = resolve_worker_count(args.workers, len(tasks))
+    if worker_count > 1:
+        LOGGER.info("Using %d worker processes", worker_count)
 
     def log_progress(task: dict[str, object], result: dict[str, object], index: int) -> None:
         LOGGER.debug(
@@ -337,7 +335,7 @@ def main() -> None:  # noqa: D401 - CLI entry point
     rows = execute_simulation_tasks(
         tasks,
         run_single_configuration,
-        max_workers=args.workers,
+        max_workers=worker_count,
         progress_callback=log_progress,
     )
 

--- a/scripts/mne3sd/article_a/scenarios/simulate_pdr_density.py
+++ b/scripts/mne3sd/article_a/scenarios/simulate_pdr_density.py
@@ -26,8 +26,10 @@ sys.path.insert(
 from loraflexsim.launcher import Simulator  # noqa: E402
 from scripts.mne3sd.common import (  # noqa: E402
     add_execution_profile_argument,
+    add_worker_argument,
     execute_simulation_tasks,
     resolve_execution_profile,
+    resolve_worker_count,
     summarise_metrics,
     write_csv,
 )
@@ -254,12 +256,7 @@ def main() -> None:  # noqa: D401 - CLI entry point
         action="store_true",
         help="Enable verbose logging",
     )
-    parser.add_argument(
-        "--workers",
-        type=positive_int,
-        default=1,
-        help="Number of parallel worker processes to use",
-    )
+    add_worker_argument(parser)
     add_execution_profile_argument(parser)
     args = parser.parse_args()
 
@@ -326,8 +323,9 @@ def main() -> None:  # noqa: D401 - CLI entry point
             )
             seed_counter += 1
 
-    if args.workers > 1:
-        LOGGER.info("Using %d worker processes", args.workers)
+    worker_count = resolve_worker_count(args.workers, len(tasks))
+    if worker_count > 1:
+        LOGGER.info("Using %d worker processes", worker_count)
 
     def log_progress(task: dict[str, object], result: dict[str, object], index: int) -> None:
         LOGGER.debug(
@@ -341,7 +339,7 @@ def main() -> None:  # noqa: D401 - CLI entry point
     results = execute_simulation_tasks(
         tasks,
         run_single_configuration,
-        max_workers=args.workers,
+        max_workers=worker_count,
         progress_callback=log_progress,
     )
 

--- a/scripts/mne3sd/article_b/scenarios/run_mobility_gateway_sweep.py
+++ b/scripts/mne3sd/article_b/scenarios/run_mobility_gateway_sweep.py
@@ -43,7 +43,9 @@ from loraflexsim.launcher import (  # noqa: E402
 )
 from scripts.mne3sd.common import (
     add_execution_profile_argument,
+    add_worker_argument,
     resolve_execution_profile,
+    resolve_worker_count,
     summarise_metrics,
     write_csv,
 )
@@ -353,12 +355,7 @@ def main() -> None:  # noqa: D401 - CLI entry point
     )
     parser.add_argument("--adr-node", action="store_true", help="Enable ADR on the devices")
     parser.add_argument("--adr-server", action="store_true", help="Enable ADR on the server")
-    parser.add_argument(
-        "--workers",
-        type=positive_int,
-        default=1,
-        help="Number of parallel workers used to execute simulation replicates",
-    )
+    add_worker_argument(parser)
     add_execution_profile_argument(parser)
     args = parser.parse_args()
 
@@ -377,7 +374,7 @@ def main() -> None:  # noqa: D401 - CLI entry point
     nodes = args.nodes if profile != "ci" else min(args.nodes, CI_NODES)
     packets = args.packets if profile != "ci" else min(args.packets, CI_PACKETS)
     replicates = args.replicates if profile != "ci" else CI_REPLICATES
-    workers = min(args.workers, replicates)
+    workers = resolve_worker_count(args.workers, replicates)
 
     models = [
         ("random_waypoint", RandomWaypoint),

--- a/scripts/mne3sd/article_b/scenarios/run_mobility_range_sweep.py
+++ b/scripts/mne3sd/article_b/scenarios/run_mobility_range_sweep.py
@@ -35,7 +35,9 @@ sys.path.insert(
 from loraflexsim.launcher import RandomWaypoint, Simulator, SmoothMobility  # noqa: E402
 from scripts.mne3sd.common import (
     add_execution_profile_argument,
+    add_worker_argument,
     resolve_execution_profile,
+    resolve_worker_count,
     summarise_metrics,
     write_csv,
 )
@@ -241,12 +243,7 @@ def main() -> None:  # noqa: D401 - CLI entry point
     )
     parser.add_argument("--adr-node", action="store_true", help="Enable ADR on the devices")
     parser.add_argument("--adr-server", action="store_true", help="Enable ADR on the server")
-    parser.add_argument(
-        "--workers",
-        type=positive_int,
-        default=1,
-        help="Number of parallel workers used to execute simulation replicates",
-    )
+    add_worker_argument(parser)
     add_execution_profile_argument(parser)
     args = parser.parse_args()
 
@@ -259,7 +256,7 @@ def main() -> None:  # noqa: D401 - CLI entry point
     nodes = args.nodes if profile != "ci" else min(args.nodes, CI_NODES)
     packets = args.packets if profile != "ci" else min(args.packets, CI_PACKETS)
     replicates = args.replicates if profile != "ci" else CI_REPLICATES
-    workers = min(args.workers, replicates)
+    workers = resolve_worker_count(args.workers, replicates)
 
     models = [
         ("random_waypoint", RandomWaypoint),

--- a/scripts/mne3sd/article_b/scenarios/run_mobility_speed_sweep.py
+++ b/scripts/mne3sd/article_b/scenarios/run_mobility_speed_sweep.py
@@ -38,7 +38,9 @@ sys.path.insert(
 from loraflexsim.launcher import RandomWaypoint, Simulator, SmoothMobility  # noqa: E402
 from scripts.mne3sd.common import (
     add_execution_profile_argument,
+    add_worker_argument,
     resolve_execution_profile,
+    resolve_worker_count,
     summarise_metrics,
     write_csv,
 )
@@ -251,12 +253,7 @@ def main() -> None:  # noqa: D401 - CLI entry point
     )
     parser.add_argument("--adr-node", action="store_true", help="Enable ADR on the devices")
     parser.add_argument("--adr-server", action="store_true", help="Enable ADR on the server")
-    parser.add_argument(
-        "--workers",
-        type=positive_int,
-        default=1,
-        help="Number of parallel workers used to execute simulation replicates",
-    )
+    add_worker_argument(parser)
     add_execution_profile_argument(parser)
     args = parser.parse_args()
 
@@ -274,7 +271,7 @@ def main() -> None:  # noqa: D401 - CLI entry point
     nodes = args.nodes if profile != "ci" else min(args.nodes, CI_NODES)
     packets = args.packets if profile != "ci" else min(args.packets, CI_PACKETS)
     replicates = args.replicates if profile != "ci" else CI_REPLICATES
-    workers = min(args.workers, replicates)
+    workers = resolve_worker_count(args.workers, replicates)
 
     models = [
         ("random_waypoint", RandomWaypoint),

--- a/tests/test_mne3sd_common_workers.py
+++ b/tests/test_mne3sd_common_workers.py
@@ -1,0 +1,45 @@
+import argparse
+import sys
+import types
+
+import pytest
+
+
+matplotlib_stub = types.ModuleType("matplotlib")
+pyplot_stub = types.ModuleType("matplotlib.pyplot")
+pyplot_stub.rcParams = {}
+pyplot_stub.rcdefaults = lambda: None
+sys.modules.setdefault("matplotlib", matplotlib_stub)
+sys.modules["matplotlib.pyplot"] = pyplot_stub
+
+from scripts.mne3sd.common import add_worker_argument, resolve_worker_count
+
+
+@pytest.mark.parametrize("value, expected", [("3", 3), ("auto", "auto")])
+def test_add_worker_argument_accepts_int_and_auto(value, expected):
+    parser = argparse.ArgumentParser()
+    add_worker_argument(parser)
+    args = parser.parse_args(["--workers", value])
+    assert args.workers == expected
+
+
+def test_add_worker_argument_rejects_invalid_values():
+    parser = argparse.ArgumentParser()
+    add_worker_argument(parser)
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--workers", "0"])
+
+
+def test_resolve_worker_count_limits_to_tasks(monkeypatch):
+    monkeypatch.setattr("scripts.mne3sd.common.os.cpu_count", lambda: 8)
+    assert resolve_worker_count("auto", 3) == 3
+    assert resolve_worker_count("auto", 12) == 8
+
+
+@pytest.mark.parametrize("workers, tasks, expected", [(4, 2, 2), (4, 6, 4)])
+def test_resolve_worker_count_with_explicit_integer(workers, tasks, expected):
+    assert resolve_worker_count(workers, tasks) == expected
+
+
+def test_resolve_worker_count_without_tasks_returns_zero():
+    assert resolve_worker_count("auto", 0) == 0


### PR DESCRIPTION
## Summary
- add a reusable `--workers` argument helper that accepts integers or `auto` and resolves to the available CPU count when needed
- update the Article A and B scenario scripts to rely on the shared helper and cap worker usage to the number of scheduled tasks
- add unit tests that exercise the new worker argument parsing and resolution logic

## Testing
- pytest tests/test_mne3sd_common_workers.py

------
https://chatgpt.com/codex/tasks/task_e_68d631f935488331b871b01cd30672ca