### PR TITLE
Fix summary suffix mapping for class downlink energy profile scenario

### DIFF
--- a/scripts/mne3sd/article_a/scenarios/run_class_downlink_energy_profile.py
+++ b/scripts/mne3sd/article_a/scenarios/run_class_downlink_energy_profile.py
@@ -545,7 +545,7 @@ def main(argv: list[str] | None = None) -> None:  # noqa: D401 - CLI entry point
             "downlink_period_s": sample.get("downlink_period_s", ""),
             "downlink_payload_bytes": sample.get("downlink_payload_bytes", ""),
         }
-        for label, suffix in ("mean", "std"):
+        for label, suffix in (("mean", "mean"), ("std", "std")):
             summary_row = {"replicate": label, **base_data}
             for metric in (
                 "uplink_pdr",


### PR DESCRIPTION
## Summary
- iterate over (label, suffix) pairs when building summary rows for the class downlink energy profile scenario

## Testing
- PYTHONPATH=/tmp python -m scripts.mne3sd.article_a.scenarios.run_class_downlink_energy_profile --profile ci --runs 1 --duration 10 --nodes 2 --packet-interval 5 --downlink-period 10 --beacon-interval 10 --class-c-rx-interval 1 --workers 1 *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68d6f3688dc88331a976d193f8b13f88