### PR TITLE
Add resume support for MNE3SD scenario scripts

### DIFF
--- a/scripts/mne3sd/article_a/scenarios/run_class_load_sweep.py
+++ b/scripts/mne3sd/article_a/scenarios/run_class_load_sweep.py
@@ -33,6 +33,7 @@ from scripts.mne3sd.common import (
     add_execution_profile_argument,
     add_worker_argument,
     execute_simulation_tasks,
+    filter_completed_tasks,
     resolve_execution_profile,
     resolve_worker_count,
     summarise_metrics,
@@ -193,6 +194,11 @@ def main() -> None:  # noqa: D401 - CLI entry point
         action="store_true",
         help="Enable verbose logging",
     )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Skip simulations that already exist in the detailed CSV",
+    )
     add_worker_argument(parser, default="auto")
     add_execution_profile_argument(parser)
     args = parser.parse_args()
@@ -235,6 +241,14 @@ def main() -> None:  # noqa: D401 - CLI entry point
                         "adr_server": args.adr_server,
                     }
                 )
+
+    if args.resume and RESULTS_PATH.exists():
+        original_count = len(tasks)
+        tasks = filter_completed_tasks(
+            RESULTS_PATH, ("class", "interval_s", "replicate"), tasks
+        )
+        skipped = original_count - len(tasks)
+        LOGGER.info("Skipping %d previously completed task(s) thanks to --resume", skipped)
 
     worker_count = resolve_worker_count(args.workers, len(tasks))
     if worker_count > 1:

--- a/scripts/mne3sd/article_a/scenarios/simulate_energy_classes.py
+++ b/scripts/mne3sd/article_a/scenarios/simulate_energy_classes.py
@@ -41,6 +41,7 @@ from scripts.mne3sd.common import (  # noqa: E402
     add_execution_profile_argument,
     add_worker_argument,
     execute_simulation_tasks,
+    filter_completed_tasks,
     resolve_execution_profile,
     resolve_worker_count,
     summarise_metrics,
@@ -257,6 +258,11 @@ def main() -> None:  # noqa: D401 - CLI entry point
         help="Enable ADR on the server (MAC parameter)",
     )
     parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Skip simulations that already exist in the detailed CSV",
+    )
+    parser.add_argument(
         "--verbose",
         action="store_true",
         help="Enable verbose logging",
@@ -316,6 +322,14 @@ def main() -> None:  # noqa: D401 - CLI entry point
             }
         )
         seed_counter += 1
+
+    if args.resume and DETAIL_CSV.exists():
+        original_count = len(tasks)
+        tasks = filter_completed_tasks(
+            DETAIL_CSV, ("class", "duty_cycle", "replicate"), tasks
+        )
+        skipped = original_count - len(tasks)
+        LOGGER.info("Skipping %d previously completed task(s) thanks to --resume", skipped)
 
     worker_count = resolve_worker_count(args.workers, len(tasks))
     if worker_count > 1:

--- a/scripts/mne3sd/article_a/scenarios/simulate_pdr_load.py
+++ b/scripts/mne3sd/article_a/scenarios/simulate_pdr_load.py
@@ -27,6 +27,7 @@ from scripts.mne3sd.common import (  # noqa: E402
     add_execution_profile_argument,
     add_worker_argument,
     execute_simulation_tasks,
+    filter_completed_tasks,
     resolve_execution_profile,
     resolve_worker_count,
     summarise_metrics,
@@ -240,6 +241,11 @@ def main() -> None:  # noqa: D401 - CLI entry point
         action="store_true",
         help="Enable verbose logging",
     )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Skip simulations that already exist in the detailed CSV",
+    )
     add_worker_argument(parser, default="auto")
     add_execution_profile_argument(parser)
     args = parser.parse_args()
@@ -286,6 +292,7 @@ def main() -> None:  # noqa: D401 - CLI entry point
                     "nodes": nodes,
                     "packets": packets,
                     "interval_s": interval_s,
+                    "mode": mode,
                     "mode_label": mode,
                     "mode_capitalized": mode.capitalize(),
                     "sf_assignment": config_label,
@@ -298,6 +305,14 @@ def main() -> None:  # noqa: D401 - CLI entry point
                 }
             )
             seed_counter += 1
+
+    if args.resume and DETAIL_CSV.exists():
+        original_count = len(tasks)
+        tasks = filter_completed_tasks(
+            DETAIL_CSV, ("interval_s", "mode", "sf_assignment", "replicate"), tasks
+        )
+        skipped = original_count - len(tasks)
+        LOGGER.info("Skipping %d previously completed task(s) thanks to --resume", skipped)
 
     worker_count = resolve_worker_count(args.workers, len(tasks))
     if worker_count > 1:


### PR DESCRIPTION
## Summary
- add a shared filter_completed_tasks helper to drop already recorded replicates
- expose a --resume flag across the article A scenarios to skip completed CSV entries
- update mobility sweeps to use dict-based tasks, logging, and resume-aware filtering

## Testing
- python -m compileall scripts/mne3sd

------
https://chatgpt.com/codex/tasks/task_e_68d70ff364a88331b448a61e588263bf