### PR TITLE
Add fast execution profile for Article A scripts

### DIFF
--- a/scripts/mne3sd/article_a/README.md
+++ b/scripts/mne3sd/article_a/README.md
@@ -24,6 +24,7 @@ Les scripts de `plots/` suivent la même logique :
 Tous les lanceurs de scénarios acceptent l'option commune `--profile` (ou la variable d'environnement `MNE3SD_PROFILE`) pour basculer entre des presets :
 
 - `full` *(valeur par défaut)* – conserve les paramètres de publication décrits dans chaque script.
+- `fast` – limite le nombre de nœuds à 150 et réduit le volume de paquets/répétitions pour accélérer les itérations locales. C'est le réglage conseillé pour des itérations rapides sous Windows 11.
 - `ci` – réduit le nombre de nœuds, de répétitions et l'étendue des paramètres explorés afin d'accélérer les tests automatisés et les vérifications rapides, tout en exerçant l'intégralité de la chaîne.
 
 ## Arborescence et artefacts

--- a/scripts/mne3sd/article_a/scenarios/run_class_downlink_energy_profile.py
+++ b/scripts/mne3sd/article_a/scenarios/run_class_downlink_energy_profile.py
@@ -50,6 +50,10 @@ RESULTS_PATH = (
 CI_RUNS = 1
 CI_DURATION_S = 900.0
 CI_NODES = 25
+FAST_RUNS = 3
+FAST_NODE_CAP = 150
+FAST_PAYLOAD_SIZE = 12
+FAST_DOWNLINK_PAYLOAD = 6
 
 FIELDNAMES = [
     "class",
@@ -444,7 +448,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     profile = resolve_execution_profile(args.profile)
     args.profile = profile
 
-    if profile != "ci" and args.runs < 5:
+    if profile == "fast":
+        args.runs = max(1, min(args.runs, FAST_RUNS))
+        args.nodes = min(args.nodes, FAST_NODE_CAP)
+        args.payload_size = min(args.payload_size, FAST_PAYLOAD_SIZE)
+        args.downlink_payload = min(args.downlink_payload, FAST_DOWNLINK_PAYLOAD)
+    elif profile != "ci" and args.runs < 5:
         parser.error("--runs must be at least 5 to ensure statistical confidence")
 
     if profile == "ci":

--- a/scripts/mne3sd/article_a/scenarios/simulate_energy_classes.py
+++ b/scripts/mne3sd/article_a/scenarios/simulate_energy_classes.py
@@ -69,6 +69,10 @@ CI_REPLICATES = 1
 CI_CLASSES = ("A",)
 CI_DUTY_CYCLES = (0.01,)
 
+FAST_NODE_CAP = 150
+FAST_PACKETS = 20
+FAST_REPLICATES = 3
+
 
 def positive_int(value: str) -> int:
     """Return ``value`` converted to a strictly positive integer."""
@@ -286,6 +290,10 @@ def main() -> None:  # noqa: D401 - CLI entry point
         nodes = min(nodes, CI_NODES)
         packets = min(packets, CI_PACKETS)
         replicates = min(replicates, CI_REPLICATES)
+    elif profile == "fast":
+        nodes = min(nodes, FAST_NODE_CAP)
+        packets = min(packets, FAST_PACKETS)
+        replicates = min(replicates, FAST_REPLICATES)
 
     LOGGER.info(
         "Simulating energy consumption for classes %s with duty cycles %s",

--- a/scripts/mne3sd/article_a/scenarios/simulate_pdr_density.py
+++ b/scripts/mne3sd/article_a/scenarios/simulate_pdr_density.py
@@ -52,6 +52,10 @@ CI_NODE_COUNTS = (50,)
 CI_SF_MODES = ("adaptive",)
 CI_REPLICATES = 1
 
+FAST_NODE_CAP = 150
+FAST_REPLICATES = 3
+FAST_PACKETS = 10
+
 
 def positive_float(value: str) -> float:
     """Return ``value`` converted to a strictly positive float."""
@@ -283,6 +287,17 @@ def main() -> None:  # noqa: D401 - CLI entry point
         sf_modes = list(CI_SF_MODES)
         replicates = min(replicates, CI_REPLICATES)
         packets = min(packets, 5)
+    elif profile == "fast":
+        replicates = min(replicates, FAST_REPLICATES)
+        packets = min(packets, FAST_PACKETS)
+        clamped_nodes: list[int] = []
+        seen_nodes: set[int] = set()
+        for count in node_counts:
+            limited = min(count, FAST_NODE_CAP)
+            if limited not in seen_nodes:
+                clamped_nodes.append(limited)
+                seen_nodes.add(limited)
+        node_counts = clamped_nodes
 
     side_m = area_side_from_surface(area_km2)
     LOGGER.info(

--- a/scripts/mne3sd/article_a/scenarios/simulate_pdr_load.py
+++ b/scripts/mne3sd/article_a/scenarios/simulate_pdr_load.py
@@ -50,6 +50,10 @@ CI_INTERVALS = (600.0,)
 CI_MODES = ("random",)
 CI_REPLICATES = 1
 
+FAST_NODE_CAP = 150
+FAST_REPLICATES = 3
+FAST_PACKETS = 15
+
 
 def positive_int(value: str) -> int:
     """Return ``value`` converted to a strictly positive integer."""
@@ -268,6 +272,10 @@ def main() -> None:  # noqa: D401 - CLI entry point
         replicates = min(replicates, CI_REPLICATES)
         nodes = min(nodes, 30)
         packets = min(packets, 10)
+    elif profile == "fast":
+        replicates = min(replicates, FAST_REPLICATES)
+        packets = min(packets, FAST_PACKETS)
+        nodes = min(nodes, FAST_NODE_CAP)
 
     LOGGER.info(
         "Simulating PDR for %d nodes with intervals %s and modes %s",

--- a/scripts/mne3sd/common.py
+++ b/scripts/mne3sd/common.py
@@ -75,12 +75,13 @@ def resolve_worker_count(workers: WorkerCount, task_count: int) -> int:
 
 import matplotlib.pyplot as plt
 
-PROFILE_CHOICES = ("full", "ci")
+PROFILE_CHOICES = ("full", "fast", "ci")
 PROFILE_ENV_VAR = "MNE3SD_PROFILE"
 PROFILE_HELP = (
     "Execution profile preset. 'full' keeps the publication-grade defaults while "
-    "'ci' minimises the workload for automated smoke tests. The preset can also be "
-    f"supplied through the {PROFILE_ENV_VAR} environment variable."
+    "'fast' trims simulation sizes for local iteration and 'ci' minimises the "
+    "workload for automated smoke tests. The preset can also be supplied through "
+    f"the {PROFILE_ENV_VAR} environment variable."
 )
 
 

--- a/scripts/mne3sd/run_all_article_outputs.py
+++ b/scripts/mne3sd/run_all_article_outputs.py
@@ -255,7 +255,11 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     """Return the parsed command line arguments."""
 
     parser = argparse.ArgumentParser(
-        description="Execute all MNE3SD article scenarios and/or plotting scripts.",
+        description=(
+            "Execute all MNE3SD article scenarios and/or plotting scripts. "
+            "Use '--profile fast' for quicker local iterations (recommended on "
+            "Windows 11)."
+        ),
     )
     add_execution_profile_argument(parser)
     parser.add_argument(


### PR DESCRIPTION
## Summary
- add a "fast" preset to the shared MNE3SD execution profile helper
- wire the new preset through Article A scenario scripts with lighter node counts, replicates and packet volumes
- document the profile in the Article A README and advertise it from the batch runner for quick Windows 11 iterations

## Testing
- python -m compileall scripts/mne3sd

------
https://chatgpt.com/codex/tasks/task_e_68d7130856908331958f0dc1fa765657