### PR TITLE
Aligner la fenêtre de capture sur csBegin

### DIFF
--- a/docs/equations_flora.md
+++ b/docs/equations_flora.md
@@ -61,6 +61,11 @@ Les passerelles en mode `capture_mode="flora"` reproduisent ainsi la logique du
 `LoRaReceiver` original, garantissant la parité avec les traces FLoRa lors des
 collisions entre signaux de même SF.
 
+Par ailleurs, la règle de capture des passerelles suit strictement le calcul
+``csBegin = start + T_sym · (nPreamble - 6)`` : une transmission ne bloque plus
+un paquet plus fort si son recouvrement se termine avant cette borne, ce qui
+aligne la fenêtre de capture sur celle du récepteur FLoRa historique.【F:loraflexsim/launcher/gateway.py†L259-L295】
+
 
 ### Modèle Hata‑Okumura
 

--- a/tests/test_gateway_capture.py
+++ b/tests/test_gateway_capture.py
@@ -49,6 +49,26 @@ def test_no_capture_before_five_symbols():
     assert server.packets_received == 0
 
 
+def test_interference_ends_before_cs_begin():
+    gw = Gateway(0, 0, 0)
+    server = NetworkServer()
+    server.gateways = [gw]
+
+    sf = 7
+    bw = 125e3
+    symbol_time = (2 ** sf) / bw
+    interferer_start = -0.002
+    interferer_end = interferer_start + 3 * symbol_time  # ends before csBegin (~5 symbols)
+
+    gw.start_reception(1, 1, sf, -60, interferer_end, 6.0, interferer_start, 868e6)
+    gw.start_reception(2, 2, sf, -50, 0.1, 6.0, 0.0, 868e6)
+
+    gw.end_reception(1, server, 1)
+    gw.end_reception(2, server, 2)
+
+    assert server.packets_received == 1
+
+
 def test_strong_signal_arrives_late():
     gw = Gateway(0, 0, 0)
     server = NetworkServer()


### PR DESCRIPTION
## Summary
- aligner la vérification de préambule sur le calcul csBegin en comparant la fin des interférences
- autoriser la capture d'un paquet plus fort lorsque l'interférence s'arrête avant la fenêtre FLoRa et couvrir le cas par un test
- documenter que la fenêtre de capture côté passerelle suit désormais l'algorithme FLoRa

## Testing
- pytest tests/test_gateway_capture.py


------
https://chatgpt.com/codex/tasks/task_e_68d7212d56688331a00ad353fcfe8a2d