### PR TITLE
Améliorer la documentation de reproduction FLoRa

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ les paramètres suivants sont appliqués lors de la création du `Simulator` ou 
 > 📘 Consultez également [`docs/reproduction_flora.md`](docs/reproduction_flora.md)
 > pour une checklist détaillée des paramètres et du mode compatibilité.
 
+| Phénomène | Paramètres/équations clés | Modules concernés | Détails complémentaires |
+| --- | --- | --- | --- |
+| **Pertes radio** | Courbes log-normales (`flora_loss_model`), profils `environment="flora"` et variantes Hata/Oulu | [`loraflexsim/launcher/channel.py`](loraflexsim/launcher/channel.py) | Synthèse des équations de pertes, variables `PL(d)` et constantes dans [`docs/equations_flora.md`](docs/equations_flora.md#pertes-radio) |
+| **Bruit & sensibilité** | Seuils `detection_threshold_dBm`, `energy_detection_dBm`, bruit thermique de référence | [`loraflexsim/launcher/channel.py`](loraflexsim/launcher/channel.py), [`loraflexsim/launcher/gateway.py`](loraflexsim/launcher/gateway.py) | Dérivation des équations de bruit et tables de sensibilité dans [`docs/equations_flora.md`](docs/equations_flora.md#bruit-et-sensibilite) |
+| **Capture & collisions** | Fenêtre de capture (6 symboles), matrice `FLORA_NON_ORTH_DELTA`, logique `capture_mode="aloha"` | [`loraflexsim/launcher/channel.py`](loraflexsim/launcher/channel.py), [`loraflexsim/launcher/gateway.py`](loraflexsim/launcher/gateway.py) | Modélisation C++ et équations de capture détaillées dans [`docs/equations_flora.md`](docs/equations_flora.md#capture-et-collisions) |
+| **Probabilité d'erreur (PER)** | Modèles logistique/Croce, paramètres `flora_per_model`, intégration PHY | [`loraflexsim/launcher/channel.py`](loraflexsim/launcher/channel.py), [`loraflexsim/launcher/server.py`](loraflexsim/launcher/server.py) | Formules PER et coefficients normalisés décrits dans [`docs/equations_flora.md`](docs/equations_flora.md#probabilite-derreur) |
+
 - `flora_mode=True` — active automatiquement les courbes logistiques de FLoRa,
   impose le modèle physique `omnet_full`, applique le seuil de détection
   historique et réutilise les presets de propagation « flora » sur l'ensemble

--- a/docs/reproduction_flora.md
+++ b/docs/reproduction_flora.md
@@ -33,6 +33,11 @@ Lorsque les fichiers INI ne précisent pas `timeToNextPacket`, LoRaFlexSim ramè
 
 ## 4. Contrôles rapides avant validation
 
+> 🧪 **Validation d'une nouvelle version**
+> - `make validate` : exécute la batterie de tests de régression FLoRa (unitaires et intégration) décrite dans [`VALIDATION.md`](../VALIDATION.md).
+> - `python scripts/run_validation.py --output results/validation_matrix.csv` : rejoue l'ensemble des scénarios historiques et compare les métriques aux traces `.sca` de référence.
+> - Vérifiez les jeux de données dans `tests/integration/` et `tests/test_flora_*.py` avant de publier une modification impactant `channel.py`, `gateway.py` ou `server.py`.
+
 | Élément | Vérification | Commande/conseil |
 | --- | --- | --- |
 | Paramètres radio | `flora_mode=True`, `phy_model="flora"`, preset `environment` cohérent | Inspecter `simulator.flora_mode` et `channel.environment` dans un REPL |


### PR DESCRIPTION
## Summary
- enrich the "Reproduire FLoRa" section with a table of critical equations and parameters pointing to detailed documentation
- highlight the channel, gateway, and server modules involved in losses, noise, capture, and PER modelling
- add a validation checklist callout in docs/reproduction_flora.md covering make validate and run_validation.py

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d726d4fb6c833185ec066d5f73a142