### PR TITLE
Ajout de validations multi-SF et alignement OMNeT++

### DIFF
--- a/tests/data/flora_gateway_reference.json
+++ b/tests/data/flora_gateway_reference.json
@@ -1,0 +1,44 @@
+{
+  "cases": [
+    {
+      "rssi": [-50.0, -55.0],
+      "start": [0.0, 0.0065],
+      "end": [0.1, 0.1065],
+      "sf": [7, 7],
+      "preamble": [6, 6],
+      "expected": [true, false]
+    },
+    {
+      "rssi": [-55.0, -50.0],
+      "start": [0.0, 0.0065],
+      "end": [0.1, 0.1065],
+      "sf": [7, 7],
+      "preamble": [6, 6],
+      "expected": [false, true]
+    },
+    {
+      "rssi": [-45.0, -58.0],
+      "start": [0.0, 0.0065],
+      "end": [0.1, 0.1065],
+      "sf": [7, 8],
+      "preamble": [8, 8],
+      "expected": [true, false]
+    },
+    {
+      "rssi": [-60.0, -50.0],
+      "start": [0.0, 0.0065],
+      "end": [0.1, 0.1065],
+      "sf": [9, 7],
+      "preamble": [8, 8],
+      "expected": [false, true]
+    },
+    {
+      "rssi": [-50.0, -55.0, -52.0],
+      "start": [0.0, 0.0065, 0.009],
+      "end": [0.12, 0.1265, 0.129],
+      "sf": [7, 8, 9],
+      "preamble": [9, 9, 9],
+      "expected": [true, false, false]
+    }
+  ]
+}


### PR DESCRIPTION
## Résumé
- étendre les tests de capture passerelle pour couvrir plusieurs SF et différentes longueurs de préambule basées sur la matrice `FLORA_NON_ORTH_DELTA`
- ajouter l’artefact `tests/data/flora_gateway_reference.json` et un test qui compare le comportement du gateway au modèle OMNeT++
- automatiser la vérification de référence OMNeT++ dans `scripts/run_validation.py`

## Tests
- `pytest tests/test_gateway_capture.py tests/test_collision_capture.py`
- `python scripts/run_validation.py --output /tmp/validation_test.csv --repeat 1`


------
https://chatgpt.com/codex/tasks/task_e_68d72abdc7488331aff88edf7afc1274