### PR TITLE
Add simulated duration limit to dashboard fast-forward

### DIFF
--- a/loraflexsim/launcher/dashboard.py
+++ b/loraflexsim/launcher/dashboard.py
@@ -184,11 +184,30 @@ mobility_model_select = pn.widgets.Select(
 )
 
 # --- Durée réelle de simulation et bouton d'accélération ---
+sim_duration_input = pn.widgets.FloatInput(
+    name="Durée simulée max (s)", value=0.0, step=1.0, start=0.0
+)
 real_time_duration_input = pn.widgets.FloatInput(name="Durée réelle max (s)", value=86400.0, step=1.0, start=0.0)
 fast_forward_button = pn.widgets.Button(
     name="Accélérer jusqu'à la fin", button_type="primary", disabled=True
 )
-fast_forward_button.disabled = int(packets_input.value) <= 0
+fast_forward_button.disabled = True
+
+
+def _has_simulation_limit_from_inputs() -> bool:
+    return int(packets_input.value) > 0 or float(sim_duration_input.value) > 0.0
+
+
+def _has_simulation_limit_from_sim() -> bool:
+    if sim is None:
+        return _has_simulation_limit_from_inputs()
+    has_packets = getattr(sim, "packets_to_send", 0) > 0
+    sim_duration = getattr(sim, "sim_duration_limit", None)
+    return has_packets or (sim_duration is not None and sim_duration > 0.0)
+
+
+def _refresh_fast_forward_state_from_inputs() -> None:
+    fast_forward_button.disabled = not _has_simulation_limit_from_inputs()
 
 # --- Paramètres radio FLoRa ---
 flora_mode_toggle = pn.widgets.Toggle(name="Mode FLoRa complet", button_type="primary", value=True)
@@ -615,9 +634,9 @@ def setup_simulation(seed_offset: int = 0):
         return
 
     # Valider que des paquets ou une durée réelle sont définis
-    if int(packets_input.value) <= 0 and float(real_time_duration_input.value) <= 0:
+    if not _has_simulation_limit_from_inputs() and float(real_time_duration_input.value) <= 0:
         export_message.object = (
-            "⚠️ Définissez un nombre de paquets ou une durée réelle supérieurs à 0 !"
+            "⚠️ Définissez un nombre de paquets, une durée simulée ou une durée réelle supérieurs à 0 !"
         )
         return
 
@@ -672,6 +691,8 @@ def setup_simulation(seed_offset: int = 0):
         )
 
 
+    sim_duration_limit = float(sim_duration_input.value)
+
     sim = Simulator(
         num_nodes=int(num_nodes_input.value),
         num_gateways=int(num_gateways_input.value),
@@ -680,6 +701,9 @@ def setup_simulation(seed_offset: int = 0):
         packet_interval=float(interval_input.value),
         first_packet_interval=float(first_packet_input.value),
         packets_to_send=int(packets_input.value),
+        simulation_duration=(
+            sim_duration_limit if sim_duration_limit > 0.0 else None
+        ),
         adr_node=adr_node_checkbox.value,
         adr_server=adr_server_checkbox.value,
         mobility=mobility_checkbox.value,
@@ -794,9 +818,10 @@ def setup_simulation(seed_offset: int = 0):
     seed_input.disabled = True
     num_runs_input.disabled = True
     real_time_duration_input.disabled = True
+    sim_duration_input.disabled = True
     start_button.disabled = True
     stop_button.disabled = False
-    fast_forward_button.disabled = sim.packets_to_send <= 0
+    fast_forward_button.disabled = not _has_simulation_limit_from_sim()
     pause_button.disabled = False
     pause_button.name = "⏸ Pause"
     pause_button.button_type = "primary"
@@ -827,9 +852,9 @@ def on_start(event):
         return
 
     # Valider les entrées avant de démarrer
-    if int(packets_input.value) <= 0 and float(real_time_duration_input.value) <= 0:
+    if not _has_simulation_limit_from_inputs() and float(real_time_duration_input.value) <= 0:
         export_message.object = (
-            "⚠️ Définissez un nombre de paquets ou une durée réelle supérieurs à 0 !"
+            "⚠️ Définissez un nombre de paquets, une durée simulée ou une durée réelle supérieurs à 0 !"
         )
         return
 
@@ -926,6 +951,7 @@ def on_stop(event):
     seed_input.disabled = False
     num_runs_input.disabled = False
     real_time_duration_input.disabled = False
+    sim_duration_input.disabled = False
     start_button.disabled = False
     stop_button.disabled = True
     fast_forward_button.disabled = True
@@ -1028,9 +1054,10 @@ def fast_forward(event=None):
             on_stop(None)
             return
         auto_fast_forward = True
-        if sim.packets_to_send == 0:
+        if not _has_simulation_limit_from_sim():
+            auto_fast_forward = False
             export_message.object = (
-                "⚠️ Définissez un nombre de paquets par nœud supérieur à 0 "
+                "⚠️ Définissez un nombre de paquets par nœud ou une durée simulée supérieure à 0 "
                 "pour utiliser l'accélération."
             )
             return
@@ -1078,19 +1105,23 @@ def fast_forward(event=None):
                 if current_sim.packets_to_send > 0
                 else None
             )
+            sim_duration = getattr(current_sim, "sim_duration_limit", None)
             last = -1
             while current_sim.event_queue and current_sim.running:
                 current_sim.step()
+                pct: int | None = None
                 if total_packets:
                     pct = int(current_sim.packets_sent / total_packets * 100)
-                    if pct != last:
-                        last = pct
-                        if current_session_alive():
-                            current_doc.add_next_tick_callback(
-                                lambda val=pct: setattr(
-                                    current_fast_forward_progress, "value", val
-                                )
+                elif sim_duration and sim_duration > 0.0:
+                    pct = int(min(current_sim.current_time / sim_duration * 100, 100))
+                if pct is not None and pct != last:
+                    last = pct
+                    if current_session_alive():
+                        current_doc.add_next_tick_callback(
+                            lambda val=pct: setattr(
+                                current_fast_forward_progress, "value", val
                             )
+                        )
 
             def update_ui():
                 current_fast_forward_progress.value = 100
@@ -1177,7 +1208,7 @@ def on_pause(event=None):
             chrono_callback = pn.state.add_periodic_callback(periodic_chrono_update, period=100, timeout=None)
         pause_button.name = "⏸ Pause"
         pause_button.button_type = "primary"
-        fast_forward_button.disabled = False
+        fast_forward_button.disabled = not _has_simulation_limit_from_sim()
         paused = False
 
 
@@ -1232,16 +1263,22 @@ def on_flora_toggle(event):
 
 flora_mode_toggle.param.watch(on_flora_toggle, "value")
 
-# --- Mise à jour du bouton d'accélération lorsqu'on change le nombre de paquets ---
+# --- Mise à jour du bouton d'accélération lorsqu'on change les limites de simulation ---
 def on_packets_change(event):
-    """Enable fast forward only when packets are defined."""
-    fast_forward_button.disabled = int(event.new) <= 0
+    _refresh_fast_forward_state_from_inputs()
+
+
+def on_sim_duration_change(event):
+    _refresh_fast_forward_state_from_inputs()
 
 
 packets_input.param.watch(on_packets_change, "value")
+sim_duration_input.param.watch(on_sim_duration_change, "value")
 heatmap_res_slider.param.watch(update_heatmap, "value")
 hist_metric_select.param.watch(lambda event: update_histogram(), "value")
 show_paths_checkbox.param.watch(lambda event: update_map(), "value")
+
+_refresh_fast_forward_state_from_inputs()
 
 
 def _on_adr_select(event):
@@ -1287,6 +1324,7 @@ controls = pn.WidgetBox(
     battery_capacity_input,
     payload_size_input,
     node_class_select,
+    sim_duration_input,
     real_time_duration_input,
     pn.Row(start_button, stop_button),
     pn.Row(fast_forward_button, pause_button),


### PR DESCRIPTION
## Summary
- add a simulated duration input to the dashboard, wiring the fast-forward controls to accept either a packet or duration limit
- propagate the simulated duration to the Simulator and stop stepping once the target time is reached
- compute fast-forward progress from the simulated time when no packet limit is configured

## Testing
- pytest tests/test_fast_forward_finished.py

------
https://chatgpt.com/codex/tasks/task_e_68d7ebefc8588331acf6e6498a667bf5