### PR TITLE
Fix FLoRa energy detection floor handling

### DIFF
--- a/loraflexsim/launcher/channel.py
+++ b/loraflexsim/launcher/channel.py
@@ -115,7 +115,16 @@ class Channel:
             if bw in tables
         ]
         if candidates:
-            return min(candidates)
+            # ``FLORA_SENSITIVITY`` stores detection thresholds per SF.  Those
+            # values are always lower (more negative) than the dedicated
+            # ``energyDetection`` floor enforced by FLoRa (−90 dBm).  Returning
+            # the minimum would therefore authorise any frame stronger than the
+            # most sensitive SF, which is incorrect for the energy detection
+            # stage.  We instead clamp the result with the documented
+            # ``FLORA_ENERGY_DETECTION_DBM`` so that gateways ignore frames whose
+            # RSSI stays below −90 dBm, matching the behaviour exercised in
+            # ``test_flora_energy_detection_filters_frames``.
+            return max(max(candidates), cls.FLORA_ENERGY_DETECTION_DBM)
         return cls.FLORA_ENERGY_DETECTION_DBM
 
     @classmethod


### PR DESCRIPTION
## Summary
- clamp the FLoRa energy detection helper to the documented −90 dBm floor when deriving it from the sensitivity table
- align the long-range preset validation with the scenario helpers by applying the sensitivity-based energy floor

## Testing
- pytest tests/test_flora_defaults.py::test_flora_energy_detection_filters_frames tests/test_long_range_presets.py::test_long_range_presets_pdr
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d801cd37248331b7e461e51a304e56