### PR TITLE
Add metrics timeline tracking and export

### DIFF
--- a/results/README.md
+++ b/results/README.md
@@ -12,3 +12,12 @@
 - Marge SNR pour SF12 : 2,39 dB (maximum observé).
 
 Observation notable : le preset `flora_hata` conserve une livraison parfaite pour les paquets SF11 et SF10, tandis que les SF12 et SF9 subissent une légère baisse (≤ 8 points de pourcentage) en raison des liaisons longues distances.
+
+## Export des timelines de métriques
+
+Le tableau de bord Panel permet désormais d'exporter, en plus des événements et
+des métriques agrégées, une timeline détaillée par run. Le bouton **Exporter**
+crée un fichier `metrics_timeline_<horodatage>.csv` obtenu via `pandas.concat`
+de toutes les timelines de runs. Chaque ligne correspond à un événement
+`TX_END` et contient notamment l'instant simulé, la PDR cumulée, les collisions
+cumulées, l'énergie totale et le débit instantané.

--- a/tests/test_exporter_csv.py
+++ b/tests/test_exporter_csv.py
@@ -14,9 +14,21 @@ def test_export_to_tmp_dir(tmp_path, monkeypatch):
     df = pd.DataFrame({"a": [1], "b": [2]})
     dashboard.runs_events = [df]
     dashboard.runs_metrics = [{"PDR": 100}]
+    dashboard.runs_metrics_timeline = [
+        pd.DataFrame(
+            {
+                "time_s": [0.5],
+                "PDR": [1.0],
+                "tx_attempted": [1],
+                "delivered": [1],
+                "collisions": [0],
+                "instant_throughput_bps": [160.0],
+            }
+        )
+    ]
     dashboard.export_message = pn.pane.Markdown()
     monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: None)
     monkeypatch.chdir(tmp_path)
     dashboard.exporter_csv()
-    files = list(tmp_path.glob("*.csv"))
-    assert len(files) == 2
+    files = sorted(tmp_path.glob("*.csv"))
+    assert len(files) == 3

--- a/tests/test_metrics_timeline.py
+++ b/tests/test_metrics_timeline.py
@@ -1,0 +1,44 @@
+import pytest
+
+from loraflexsim.launcher.simulator import Simulator
+
+
+def _timeline_records(timeline):
+    if hasattr(timeline, "to_dict"):
+        try:
+            return timeline.to_dict(orient="records")  # type: ignore[call-arg]
+        except TypeError:
+            # Compatibilité éventuelle avec DataFrame.to_dict("records")
+            return timeline.to_dict("records")  # type: ignore[call-arg]
+    return [dict(entry) for entry in timeline]
+
+
+def test_metrics_timeline_matches_tx_end_events():
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        transmission_mode="Periodic",
+        packet_interval=1.0,
+        packets_to_send=3,
+        duty_cycle=None,
+        seed=123,
+    )
+    sim.run()
+
+    timeline = sim.get_metrics_timeline()
+    records = _timeline_records(timeline)
+
+    assert len(records) == sim.tx_attempted == 3
+    assert records[0]["time_s"] >= 0.0
+
+    for idx, entry in enumerate(records, start=1):
+        assert entry["tx_attempted"] == idx
+        tx = entry["tx_attempted"]
+        delivered = entry["delivered"]
+        expected_pdr = delivered / tx if tx > 0 else 0.0
+        assert entry["PDR"] == pytest.approx(expected_pdr)
+        assert entry["collisions"] == 0
+
+    final = records[-1]
+    assert final["PDR"] == pytest.approx(sim.rx_delivered / sim.tx_attempted)
+    assert final["energy_J"] >= 0.0


### PR DESCRIPTION
## Summary
- track cumulative metrics timeline snapshots in the simulator and expose an accessor
- update the dashboard to keep per-run timelines, export them to CSV, and document the new artifact
- add tests covering the metrics timeline content and exporter behaviour

## Testing
- pytest tests/test_metrics_timeline.py tests/test_exporter_csv.py

------
https://chatgpt.com/codex/tasks/task_e_68d815f23fd083318b9beebc77fa63bd