### PR TITLE
Refactor validation matrix to avoid pandas dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,9 @@ Deux commandes permettent de rejouer la matrice de validation et de suivre les
 
 1. `pytest tests/integration/test_validation_matrix.py` exécute chaque scénario
    et vérifie que les écarts de PDR, de collisions et de SNR restent dans les
-   tolérances définies par scénario.【F:tests/integration/test_validation_matrix.py†L1-L78】
+   tolérances définies par scénario. Le chargement des références repose sur le
+   module standard `csv`, ce qui supprime toute dépendance optionnelle et rend
+   la matrice reproductible sur toutes les plateformes.【F:tests/integration/test_validation_matrix.py†L1-L83】【F:loraflexsim/validation/reference_loader.py†L1-L109】
 2. `python scripts/run_validation.py --output results/validation_matrix.csv`
    (script disponible via [scripts/run_validation.py](scripts/run_validation.py))
    génère un rapport synthétique et retourne un code de sortie non nul si une

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -83,7 +83,7 @@ Les tests d'intégration `pytest` exécutent cette matrice et vérifient que le 
 
 ## Résultats récents
 
-La campagne `pytest` est actuellement entièrement sautée faute de dépendance `pandas`, ce qui impose de suivre le script CLI pour obtenir les métriques réelles.【F:tests/integration/test_validation_matrix.py†L9-L24】 L'exécution du run `python scripts/run_validation.py --output results/validation_matrix.csv` confirme que tous les scénarios reviennent au statut `ok`. Une légère dérive a été observée sur le preset longue portée : la tolérance PDR passe à `±0.015` et celle du SNR à `±0.22` pour absorber un écart stable de `0.014` paquet livré et `0.21 dB` sur plusieurs runs.【F:loraflexsim/validation/__init__.py†L114-L130】【F:results/validation_matrix.csv†L2-L16】
+La campagne `pytest` d'intégration tourne désormais sur toutes les plateformes sans dépendance optionnelle : les métriques de référence sont chargées via le module standard `csv`, garantissant la parité avec les captures `.sca` historiques.【F:tests/integration/test_validation_matrix.py†L1-L83】【F:loraflexsim/validation/reference_loader.py†L1-L109】 L'exécution du run `python scripts/run_validation.py --output results/validation_matrix.csv` confirme que tous les scénarios reviennent au statut `ok`. Une légère dérive a été observée sur le preset longue portée : la tolérance PDR passe à `±0.015` et celle du SNR à `±0.22` pour absorber un écart stable de `0.014` paquet livré et `0.21 dB` sur plusieurs runs.【F:loraflexsim/validation/__init__.py†L83-L138】【F:results/validation_matrix.csv†L2-L16】
 
 | Scénario | ΔPDR | ΔCollisions | ΔSNR (dB) | Tolérances | Statut |
 | --- | --- | --- | --- | --- | --- |

--- a/loraflexsim/validation/__init__.py
+++ b/loraflexsim/validation/__init__.py
@@ -12,15 +12,13 @@ from functools import partial
 
 from loraflexsim.launcher import Simulator, MultiChannel, Channel
 from loraflexsim.launcher import adr_ml, explora_at
-from loraflexsim.launcher.compare_flora import (
-    load_flora_metrics,
-    load_flora_rx_stats,
-)
 from loraflexsim.launcher.smooth_mobility import SmoothMobility
 from loraflexsim.scenarios.long_range import (
     LONG_RANGE_RECOMMENDATIONS,
     create_long_range_channels,
 )
+
+from .reference_loader import load_reference_metrics
 
 
 @dataclass(frozen=True)
@@ -82,12 +80,11 @@ def compute_average_snr(sim: Simulator) -> float:
 def load_flora_reference(path: Path) -> dict[str, float]:
     """Load PDR, collisions and SNR metrics from a FLoRa export."""
 
-    flora_metrics = load_flora_metrics(path)
-    rx_stats = load_flora_rx_stats(path)
+    reference = load_reference_metrics(path)
     return {
-        "PDR": float(flora_metrics["PDR"]),
-        "collisions": float(rx_stats["collisions"]),
-        "snr": float(rx_stats["snr"]),
+        "PDR": float(reference["PDR"]),
+        "collisions": float(reference["collisions"]),
+        "snr": float(reference["snr"]),
     }
 
 

--- a/loraflexsim/validation/reference_loader.py
+++ b/loraflexsim/validation/reference_loader.py
@@ -1,0 +1,113 @@
+"""Utilities to load FLoRa reference metrics without pandas."""
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Iterable
+
+Number = float | int
+
+
+def load_reference_metrics(path: Path | str) -> dict[str, float]:
+    """Aggregate reference metrics from a FLoRa export.
+
+    The loader supports single ``.sca`` files, CSV exports and directories
+    containing one or multiple ``.sca`` captures. Only the metrics required by
+    the validation matrix (PDR, collisions and average SNR) are computed.
+    """
+
+    rows = list(_iter_reference_rows(Path(path)))
+    if not rows:
+        return {"sent": 0.0, "received": 0.0, "PDR": 0.0, "collisions": 0.0, "snr": 0.0}
+
+    total_sent = sum(_as_int(row.get("sent")) for row in rows)
+    total_received = sum(_as_int(row.get("received")) for row in rows)
+    total_collisions = sum(_as_int(row.get("collisions")) for row in rows)
+
+    snr_values = [_as_float(row.get("snr")) for row in rows if row.get("snr") is not None]
+    snr_values = [val for val in snr_values if val is not None]
+    avg_snr = sum(snr_values) / len(snr_values) if snr_values else 0.0
+
+    pdr = (total_received / total_sent) if total_sent else 0.0
+
+    return {
+        "sent": float(total_sent),
+        "received": float(total_received),
+        "PDR": float(pdr),
+        "collisions": float(total_collisions),
+        "snr": float(avg_snr),
+    }
+
+
+def _iter_reference_rows(path: Path) -> Iterable[dict[str, Number]]:
+    if path.is_dir():
+        for sca_file in sorted(path.glob("*.sca")):
+            yield _parse_sca_file(sca_file)
+        return
+
+    suffix = path.suffix.lower()
+    if suffix == ".sca":
+        yield _parse_sca_file(path)
+    else:
+        yield from _read_csv_file(path)
+
+
+def _parse_sca_file(path: Path) -> dict[str, Number]:
+    metrics: dict[str, float] = {}
+    with open(path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            parts = line.strip().split()
+            if len(parts) < 4 or parts[0] != "scalar":
+                continue
+            name = parts[2].strip('"')
+            try:
+                value = float(parts[3])
+            except ValueError:
+                continue
+            metrics[name] = metrics.get(name, 0.0) + value
+
+    row: dict[str, Number] = {}
+    for key, value in metrics.items():
+        if key in {"sent", "received", "collisions"}:
+            row[key] = int(round(value))
+        elif key in {"snr", "rssi"}:
+            row[key] = float(value)
+    return row
+
+
+def _read_csv_file(path: Path) -> Iterable[dict[str, Number]]:
+    with open(path, "r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        for raw in reader:
+            row: dict[str, Number] = {}
+            for key in ("sent", "received", "collisions", "snr"):
+                if key not in raw:
+                    continue
+                value = raw[key]
+                if value in (None, ""):
+                    continue
+                number = _as_float(value)
+                if number is None:
+                    continue
+                if key in {"sent", "received", "collisions"}:
+                    row[key] = int(round(number))
+                else:
+                    row[key] = float(number)
+            if row:
+                yield row
+
+
+def _as_float(value: Number | str | None) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_int(value: Number | str | None) -> int:
+    float_value = _as_float(value) or 0.0
+    return int(round(float_value))

--- a/tests/integration/test_validation_matrix.py
+++ b/tests/integration/test_validation_matrix.py
@@ -6,11 +6,6 @@ from pathlib import Path
 
 import pytest
 
-try:  # pragma: no cover - optional dependency
-    import pandas as _pd  # noqa: F401
-except Exception:  # pragma: no cover - skip if pandas unusable
-    pytest.skip("pandas is required for validation comparisons", allow_module_level=True)
-
 from loraflexsim.launcher import adr_ml, explora_at
 from loraflexsim.validation import (
     SCENARIOS,

--- a/tests/test_validation_reference_loader.py
+++ b/tests/test_validation_reference_loader.py
@@ -1,0 +1,39 @@
+"""Tests for the lightweight FLoRa reference loader."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from loraflexsim.validation.reference_loader import load_reference_metrics
+
+
+def test_load_reference_metrics_from_sca():
+    """The loader matches the known values from a FLoRa .sca capture."""
+
+    path = Path("tests/integration/data/long_range_flora.sca")
+    metrics = load_reference_metrics(path)
+    assert metrics["sent"] == pytest.approx(72)
+    assert metrics["received"] == pytest.approx(65)
+    assert metrics["collisions"] == pytest.approx(0)
+    assert metrics["PDR"] == pytest.approx(65 / 72)
+    assert metrics["snr"] == pytest.approx(-1.9413691511020699)
+
+
+def test_load_reference_metrics_from_csv(tmp_path):
+    """CSV exports are aggregated without relying on pandas."""
+
+    csv_file = tmp_path / "metrics.csv"
+    csv_file.write_text(
+        "sent,received,collisions,snr\n"
+        "10,9,1,1.5\n"
+        "5,4,0,2.5\n",
+        encoding="utf-8",
+    )
+
+    metrics = load_reference_metrics(csv_file)
+    assert metrics["sent"] == pytest.approx(15)
+    assert metrics["received"] == pytest.approx(13)
+    assert metrics["collisions"] == pytest.approx(1)
+    assert metrics["PDR"] == pytest.approx(13 / 15)
+    assert metrics["snr"] == pytest.approx((1.5 + 2.5) / 2)


### PR DESCRIPTION
## Summary
- add a csv-based reference loader for validation references so the matrix no longer depends on pandas
- update the integration test suite and documentation to reflect the new default behaviour across all platforms
- add unit tests ensuring the lightweight loader matches historical .sca outputs

## Testing
- pytest tests/test_validation_reference_loader.py
- pytest tests/integration/test_validation_matrix.py -k long_range --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68d81b3325fc83318c6858e413fb6830