### PR TITLE
Align default FLoRa overlap margin and add regression test

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,12 +655,15 @@ automatiquement la portée.
 
 Le tableau de bord propose désormais un bouton **Mode FLoRa complet**. Quand il
 est activé, `detection_threshold_dBm` est automatiquement fixé à `-110` dBm et
-`min_interference_time` à `5` s, valeurs tirées du fichier INI de FLoRa. Un
-profil radio ``flora`` est aussi sélectionné pour appliquer l'exposant et la
-variance de shadowing correspondants. Les champs restent modifiables si ce mode
-est désactivé. Pour reproduire fidèlement les scénarios FLoRa d'origine, pensez
-également à renseigner les positions des nœuds telles qu'indiquées dans l'INI.
-L'équivalent en script consiste à passer `flora_mode=True` au constructeur `Simulator`.
+`min_interference_time` reste par défaut à `0` s. Toute superposition, même
+infinitésimale, déclenche donc une collision conformément aux fichiers INI de
+FLoRa. Vous pouvez saisir une valeur positive pour imposer un chevauchement
+minimal personnalisé (par exemple `5` s). Un profil radio ``flora`` est aussi
+sélectionné pour appliquer l'exposant et la variance de shadowing
+correspondants. Les champs restent modifiables si ce mode est désactivé. Pour
+reproduire fidèlement les scénarios FLoRa d'origine, pensez également à
+renseigner les positions des nœuds telles qu'indiquées dans l'INI. L'équivalent
+en script consiste à passer `flora_mode=True` au constructeur `Simulator`.
 Lorsque `phy_model="omnet_full"` est utilisé (par exemple en mode FLoRa), le preset
 `environment="flora"` est désormais appliqué automatiquement afin de conserver
 un exposant de 2,7 et un shadowing de 3,57 dB identiques au modèle d'origine.

--- a/loraflexsim/launcher/simulator.py
+++ b/loraflexsim/launcher/simulator.py
@@ -307,7 +307,7 @@ class Simulator:
         :param min_interference_time: Chevauchement temporel toléré entre
             transmissions avant de les considérer en collision (s).
         :param flora_mode: Active automatiquement les réglages du mode FLoRa
-            complet (seuil -110 dBm et 5 s d'interférence minimale).
+            complet (seuil -110 dBm et chevauchement minimal nul).
         :param flora_timing: Utilise les temporisations du projet FLoRa
             (délai réseau de 10 ms et traitement serveur de 1,2 s).
         :param config_file: Fichier INI listant les positions des nœuds et
@@ -433,8 +433,6 @@ class Simulator:
                     energy_detection_dBm = min(floors) if floors else Channel.FLORA_ENERGY_DETECTION_DBM
                 else:
                     energy_detection_dBm = Channel.flora_energy_threshold(125000.0)
-            if min_interference_time == 0.0:
-                min_interference_time = 5.0
             if self.first_packet_min_delay == 0.0:
                 self.first_packet_min_delay = 5.0
         if pure_poisson_mode:

--- a/tests/test_flora_collision_regression.py
+++ b/tests/test_flora_collision_regression.py
@@ -1,0 +1,33 @@
+"""Test de régression : toute superposition en mode FLoRa provoque une collision."""
+
+from loraflexsim.launcher.simulator import Simulator
+
+
+def test_flora_mode_counts_collisions_without_overlap_margin():
+    sim = Simulator(
+        num_nodes=2,
+        num_gateways=1,
+        flora_mode=True,
+        phy_model="omnet_full",
+        packets_to_send=1,
+        mobility=False,
+        duty_cycle=None,
+        warm_up_intervals=0,
+        log_mean_after=None,
+        area_size=1.0,
+        fixed_sf=7,
+        fixed_tx_power=14.0,
+        seed=12345,
+    )
+
+    for node in sim.nodes:
+        sim.schedule_event(node, 0.0, reason="test")
+
+    while sim.step():
+        pass
+
+    metrics = sim.get_metrics()
+    sim.stop()
+
+    assert sim.packets_lost_collision > 0
+    assert metrics["collisions"] > 0


### PR DESCRIPTION
## Summary
- keep the default overlap margin at zero when running the simulator in `flora_mode`
- update the "Mode FLoRa complet" section of the README to describe the new behaviour
- add a regression test covering collisions in FLoRa mode when transmissions overlap

## Testing
- pytest tests/test_flora_collision_regression.py

------
https://chatgpt.com/codex/tasks/task_e_68d87cc328b4833186fa00864a539325