### PR TITLE
Réorganiser l'application des options rapides et d'échantillonnage

### DIFF
--- a/loraflexsim/run.py
+++ b/loraflexsim/run.py
@@ -47,14 +47,14 @@ def apply_speed_settings(
         raise ValueError("steps must be > 0")
     if nodes <= 0:
         raise ValueError("nodes must be > 0")
-    if sample_size is not None:
-        if not (0.0 < sample_size <= 1.0):
-            raise ValueError("sample_size must be within (0, 1]")
-        steps = max(1, int(math.ceil(steps * sample_size)))
     if fast:
         fast_steps = max(1, int(math.ceil(steps * _FAST_STEP_RATIO)))
         steps = min(steps, max(min_fast_steps, fast_steps))
         nodes = max(1, int(math.ceil(nodes * 0.5)))
+    if sample_size is not None:
+        if not (0.0 < sample_size <= 1.0):
+            raise ValueError("sample_size must be within (0, 1]")
+        steps = max(1, int(math.ceil(steps * sample_size)))
     return nodes, steps
 
 # Configuration du logger pour afficher les informations

--- a/tests/test_speed_settings.py
+++ b/tests/test_speed_settings.py
@@ -18,6 +18,14 @@ def test_sample_size_fraction():
     assert steps == 250
 
 
+def test_fast_then_sample_respected_fraction():
+    nodes, steps = apply_speed_settings(200, 10_000, fast=True, sample_size=0.5)
+    assert nodes == 100
+    fast_steps = min(10_000, max(600, math.ceil(10_000 * 0.1)))
+    expected_steps = max(1, math.ceil(fast_steps * 0.5))
+    assert steps == expected_steps
+
+
 def test_invalid_sample_size_raises():
     with pytest.raises(ValueError):
         apply_speed_settings(10, 100, sample_size=1.5)


### PR DESCRIPTION
## Summary
- appliquer le mode rapide avant la réduction de durée par sample_size afin de respecter la fraction demandée
- ajuster les tests unitaires pour couvrir la nouvelle combinaison fast + sample_size

## Testing
- pytest tests/test_speed_settings.py

------
https://chatgpt.com/codex/tasks/task_e_68d8838e9fa8833185412610db3856a3