### PR TITLE
Ensure deterministic RNG for mobility models

### DIFF
--- a/loraflexsim/launcher/_random.py
+++ b/loraflexsim/launcher/_random.py
@@ -1,0 +1,31 @@
+"""Utilitaires pour initialiser des générateurs pseudo-aléatoires contrôlés."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+
+SeedLike = int | Sequence[int] | None
+
+
+def ensure_rng(
+    rng: np.random.Generator | None, seed: SeedLike = 0
+) -> np.random.Generator:
+    """Retourne un :class:`~numpy.random.Generator` déterministe.
+
+    Si ``rng`` est fourni il est retourné tel quel, sinon un nouveau générateur
+    ``numpy.random.Generator`` basé sur ``numpy.random.MT19937`` est construit
+    en utilisant ``seed``. Lorsque ``seed`` vaut ``None`` un générateur non
+    déterministe est créé.
+    """
+
+    if rng is not None:
+        return rng
+    bitgen = np.random.MT19937() if seed is None else np.random.MT19937(seed)
+    return np.random.Generator(bitgen)
+
+
+__all__ = ["SeedLike", "ensure_rng"]
+

--- a/loraflexsim/launcher/gauss_markov.py
+++ b/loraflexsim/launcher/gauss_markov.py
@@ -1,6 +1,8 @@
 import math
 import numpy as np
 
+from ._random import SeedLike, ensure_rng
+
 
 class GaussMarkov:
     """Gauss–Markov mobility model with bounded area."""
@@ -15,10 +17,11 @@ class GaussMarkov:
         direction_std: float = 0.2,
         step: float = 1.0,
         rng: np.random.Generator | None = None,
+        seed: SeedLike = 0,
     ) -> None:
         self.area_size = float(area_size)
         self.mean_speed = float(mean_speed)
-        init_rng = rng or np.random.Generator(np.random.MT19937())
+        init_rng = ensure_rng(rng, seed)
         self.mean_direction = (
             mean_direction if mean_direction is not None else init_rng.random() * 2 * math.pi
         )

--- a/loraflexsim/launcher/mobility.py
+++ b/loraflexsim/launcher/mobility.py
@@ -1,6 +1,8 @@
 import math
 import numpy as np
 
+from ._random import SeedLike, ensure_rng
+
 
 class RandomWaypoint:
     """Modèle de mobilité aléatoire (Random Waypoint simplifié) pour les nœuds.
@@ -28,6 +30,7 @@ class RandomWaypoint:
         slope_limit: float | None = None,
         dynamic_obstacles: list[dict[str, float]] | None = None,
         rng: np.random.Generator | None = None,
+        seed: SeedLike = 0,
     ) -> None:
         """
         Initialise le modèle de mobilité.
@@ -66,7 +69,7 @@ class RandomWaypoint:
             self.e_rows = 0
             self.e_cols = 0
         self.dynamic_obstacles = [dict(o) for o in (dynamic_obstacles or [])]
-        self.rng = rng or np.random.Generator(np.random.MT19937())
+        self.rng = ensure_rng(rng, seed)
         self._last_obs_update = 0.0
 
     # ------------------------------------------------------------------

--- a/loraflexsim/launcher/path_mobility.py
+++ b/loraflexsim/launcher/path_mobility.py
@@ -5,6 +5,7 @@ import numpy as np
 from pathlib import Path
 from typing import List, Tuple, Iterable
 
+from ._random import SeedLike, ensure_rng
 
 class PathMobility:
     """Simple grid-based mobility that plans shortest paths avoiding obstacles."""
@@ -24,6 +25,7 @@ class PathMobility:
         slope_limit: float | None = None,
         dynamic_obstacles: Iterable[dict] | str | Path | None = None,
         rng: np.random.Generator | None = None,
+        seed: SeedLike = 0,
     ) -> None:
         """\
         :param slope_limit: Pente maximale autorisée entre deux cellules
@@ -55,7 +57,7 @@ class PathMobility:
             data = Path(dynamic_obstacles).read_text()
             dynamic_obstacles = json.loads(data)
         self.dynamic_obstacles = [dict(o) for o in (dynamic_obstacles or [])]
-        self.rng = rng or np.random.Generator(np.random.MT19937())
+        self.rng = ensure_rng(rng, seed)
         self._last_obs_update = 0.0
 
     # ------------------------------------------------------------------

--- a/loraflexsim/launcher/random_waypoint.py
+++ b/loraflexsim/launcher/random_waypoint.py
@@ -1,8 +1,11 @@
 from pathlib import Path
 from typing import Iterable, List
 
+import numpy as np
+
 from .mobility import RandomWaypoint as _BaseRandomWaypoint
 from .map_loader import load_map
+from ._random import SeedLike
 
 
 class RandomWaypoint(_BaseRandomWaypoint):
@@ -21,6 +24,8 @@ class RandomWaypoint(_BaseRandomWaypoint):
         step: float = 1.0,
         slope_scale: float = 0.1,
         dynamic_obstacles: List[dict[str, float]] | None = None,
+        rng: np.random.Generator | None = None,
+        seed: SeedLike = 0,
     ) -> None:
         if terrain is not None and isinstance(terrain, (str, Path)):
             terrain = load_map(terrain)
@@ -39,4 +44,6 @@ class RandomWaypoint(_BaseRandomWaypoint):
             step=step,
             slope_scale=slope_scale,
             dynamic_obstacles=dynamic_obstacles,
+            rng=rng,
+            seed=seed,
         )

--- a/loraflexsim/launcher/smooth_mobility.py
+++ b/loraflexsim/launcher/smooth_mobility.py
@@ -1,6 +1,8 @@
 import math
 import numpy as np
 
+from ._random import SeedLike, ensure_rng
+
 
 def bezier_point(p0, p1, p2, p3, t):
     """Return point of cubic Bezier curve for parameter t."""
@@ -30,12 +32,13 @@ class SmoothMobility:
         step: float = 1.0,
         *,
         rng: np.random.Generator | None = None,
+        seed: SeedLike = 0,
     ):
         self.area_size = area_size
         self.min_speed = min_speed
         self.max_speed = max_speed
         self.step = step
-        self.rng = rng or np.random.Generator(np.random.MT19937())
+        self.rng = ensure_rng(rng, seed)
 
     def assign(self, node):
         """Initialize path and speed for a node."""

--- a/loraflexsim/launcher/terrain_mobility.py
+++ b/loraflexsim/launcher/terrain_mobility.py
@@ -2,6 +2,8 @@ import math
 import numpy as np
 from typing import List, Tuple
 
+from ._random import SeedLike, ensure_rng
+
 
 class TerrainMapMobility:
     """Mobility following a raster terrain map with optional 3D obstacles."""
@@ -19,6 +21,7 @@ class TerrainMapMobility:
         slope_scale: float = 0.1,
         slope_limit: float | None = None,
         rng: np.random.Generator | None = None,
+        seed: SeedLike = 0,
     ) -> None:
         self.area_size = float(area_size)
         self.terrain = terrain
@@ -41,7 +44,7 @@ class TerrainMapMobility:
             self.h_cols = len(obstacle_height_map[0]) if self.h_rows else 0
         else:
             self.h_rows = self.h_cols = 0
-        self.rng = rng or np.random.Generator(np.random.MT19937())
+        self.rng = ensure_rng(rng, seed)
 
     # ------------------------------------------------------------------
     def _speed_factor_cell(self, cx: int, cy: int) -> float:

--- a/loraflexsim/launcher/waypoint_planner.py
+++ b/loraflexsim/launcher/waypoint_planner.py
@@ -3,6 +3,8 @@ import math
 import numpy as np
 from typing import List, Tuple
 
+from ._random import SeedLike, ensure_rng
+
 
 class WaypointPlanner3D:
     """A* planner avoiding obstacles and high buildings."""
@@ -18,6 +20,7 @@ class WaypointPlanner3D:
         slope_scale: float = 0.1,
         slope_limit: float | None = None,
         rng: np.random.Generator | None = None,
+        seed: SeedLike = 0,
     ) -> None:
         self.area_size = float(area_size)
         self.terrain = terrain
@@ -38,7 +41,7 @@ class WaypointPlanner3D:
             self.h_rows = self.h_cols = 0
         self.slope_scale = slope_scale
         self.slope_limit = slope_limit
-        self.rng = rng or np.random.Generator(np.random.MT19937())
+        self.rng = ensure_rng(rng, seed)
 
     # --------------------------------------------------------------
     def _terrain_factor_cell(self, cx: int, cy: int) -> float | None:

--- a/tests/test_planned_random_waypoint.py
+++ b/tests/test_planned_random_waypoint.py
@@ -18,6 +18,7 @@ def test_planner_avoids_high_obstacle():
         terrain=terrain,
         obstacle_height_map=heights,
         max_height=5,
+        seed=123,
     )
     node = Node(1, 0.0, 0.0, 7, 14)
     mobility.assign(node)
@@ -27,7 +28,7 @@ def test_planner_avoids_high_obstacle():
 
 def test_assign_sets_path():
     terrain = [[1, 1], [1, 1]]
-    mobility = PlannedRandomWaypoint(area_size=20.0, terrain=terrain)
+    mobility = PlannedRandomWaypoint(area_size=20.0, terrain=terrain, seed=123)
     node = Node(1, 5.0, 5.0, 7, 14)
     mobility.assign(node)
     assert len(node.path) >= 2

--- a/tests/test_random_waypoint_mobility.py
+++ b/tests/test_random_waypoint_mobility.py
@@ -3,7 +3,9 @@ from loraflexsim.launcher.node import Node
 
 
 def test_random_waypoint_move_within_bounds_and_updates_time():
-    mobility = RandomWaypoint(area_size=100.0, min_speed=1.0, max_speed=1.0)
+    mobility = RandomWaypoint(
+        area_size=100.0, min_speed=1.0, max_speed=1.0, seed=42
+    )
     node = Node(0, 50.0, 50.0, 7, 14)
 
     mobility.assign(node)


### PR DESCRIPTION
## Summary
- add a shared helper to build deterministic `numpy.random.Generator` instances
- update mobility-related classes to accept an explicit seed and use the shared RNG
- refresh mobility tests to pass fixed seeds and stabilise path generation

## Testing
- pytest tests/test_random_waypoint_mobility.py tests/test_planned_random_waypoint.py

------
https://chatgpt.com/codex/tasks/task_e_68d88d67ce188331bf75a71e5ef8651e