### PR TITLE
Fix missing seed parameter in Channel RNG initialization

### DIFF
--- a/loraflexsim/launcher/channel.py
+++ b/loraflexsim/launcher/channel.py
@@ -243,6 +243,7 @@ class Channel:
         channel_index: int = 0,
         orthogonal_sf: bool = True,
         rng: np.random.Generator | None = None,
+        seed: int | None = None,
     ):
         """
         Initialise le canal radio avec paramètres de propagation.


### PR DESCRIPTION
## Summary
- add the optional `seed` argument to `Channel.__init__` so the RNG fallback can use it without raising a NameError

## Testing
- pytest (fails: numerous existing validation and plotting tests require optional dependencies or strict tolerances outside the scope of this change)


------
https://chatgpt.com/codex/tasks/task_e_68d88ef8ef3c8331a51dc4d34dd4f391