### PR TITLE
Empêcher la hausse de SF ADR quand la puissance est déjà maximale

### DIFF
--- a/docs/adr_protocols.md
+++ b/docs/adr_protocols.md
@@ -23,6 +23,13 @@ Lorsque ce SNR offre une marge suffisante, l'algorithme réduit d'abord le
 spreading factor puis la puissance d'émission afin d'augmenter le débit tout en
 restant compatible avec LoRaWAN.
 
+Lorsque la marge devient négative, la puissance d'émission est relevée par pas
+de 3 dB jusqu'à retrouver une marge positive. Si la puissance atteint déjà sa
+valeur maximale (14 dBm dans le profil FLoRa), le spreading factor est
+désormais conservé, ce qui aligne LoRaFlexSim sur la logique de
+`NetworkServerApp::evaluateADR` et évite d'allonger inutilement l'airtime lorsque
+le lien est seulement limité en puissance.
+
 Dans LoRaFlexSim, la mesure utilisée correspond désormais au **SNIR remonté par
 la passerelle** ayant décodé l'uplink. Le serveur conserve un historique par
 passerelle, ce qui reproduit fidèlement le comportement de FLoRa dans les

--- a/loraflexsim/launcher/server.py
+++ b/loraflexsim/launcher/server.py
@@ -867,6 +867,8 @@ class NetworkServer:
                         while nstep < 0 and p_idx > 0:
                             p_idx -= 1
                             nstep += 1
+                        if nstep < 0 and p_idx == 0:
+                            nstep = 0
                         while nstep < 0 and sf < 12:
                             sf += 1
                             nstep += 1

--- a/tests/test_network_server.py
+++ b/tests/test_network_server.py
@@ -66,3 +66,19 @@ def test_multi_gateway_adr_history_evolution():
     history_gw2 = node.gateway_snr_history.get(gw2.id, [])
     assert len(history_gw2) == ADR_WINDOW_SIZE
     assert history_gw2[-1] == float(3 + ADR_WINDOW_SIZE)
+
+
+def test_adr_max_does_not_raise_sf_when_power_already_max():
+    server = NetworkServer(adr_method="adr-max")
+    server.adr_enabled = True
+
+    gateway = Gateway(0, 0, 0)
+    node = Node(0, 0, 0, 7, 14)
+    server.gateways = [gateway]
+    server.nodes = [node]
+
+    for event_id in range(1, ADR_WINDOW_SIZE + 1):
+        server.receive(event_id, node.id, gateway.id, snir=-5.0)
+
+    assert node.sf == 7
+    assert node.tx_power == 14


### PR DESCRIPTION
## Résumé
- empêche `NetworkServer.receive` d'augmenter le spreading factor lorsque `nstep` est négatif et que la puissance TX est déjà au niveau maximal, conformément à FLoRa
- ajoute un test de non-régression pour un uplink produisant `nstep < 0` avec une puissance de 14 dBm
- précise dans la documentation ADR que le SF est conservé lorsque la puissance maximale est atteinte

## Tests
- pytest tests/test_network_server.py

------
https://chatgpt.com/codex/tasks/task_e_68d8c1838d608331a85c0945bd822654