### PR TITLE
Ensure Class C downlinks trigger immediate RX windows

### DIFF
--- a/loraflexsim/launcher/server.py
+++ b/loraflexsim/launcher/server.py
@@ -372,7 +372,13 @@ class NetworkServer:
                 )
             elif node.class_type.upper() == "C":
                 after = self.simulator.current_time if self.simulator else 0.0
-                self.scheduler.schedule_class_c(node, after, frame, gw, priority=priority)
+                scheduled = self.scheduler.schedule_class_c(
+                    node, after, frame, gw, priority=priority
+                )
+                if self.simulator is not None:
+                    ensure = getattr(self.simulator, "ensure_class_c_rx_window", None)
+                    if ensure is not None:
+                        ensure(node, scheduled)
             else:
                 end = getattr(node, "last_uplink_end_time", None)
                 if end is not None:
@@ -417,22 +423,13 @@ class NetworkServer:
                     priority=priority,
                 )
             elif node.class_type.upper() == "C":
-                self.scheduler.schedule_class_c(node, at_time, frame, gw, priority=priority)
+                scheduled = self.scheduler.schedule_class_c(
+                    node, at_time, frame, gw, priority=priority
+                )
                 if self.simulator is not None:
-                    from .simulator import EventType
-
-                    eid = self.simulator.event_id_counter
-                    self.simulator.event_id_counter += 1
-                    if hasattr(self.simulator, "_push_event"):
-                        self.simulator._push_event(at_time, EventType.RX_WINDOW, eid, node.id)
-                    else:
-                        from .simulator import Event
-                        import heapq
-
-                        heapq.heappush(
-                            self.simulator.event_queue,
-                            Event(at_time, EventType.RX_WINDOW, eid, node.id),
-                        )
+                    ensure = getattr(self.simulator, "ensure_class_c_rx_window", None)
+                    if ensure is not None:
+                        ensure(node, scheduled)
             else:
                 self.scheduler.schedule(node.id, at_time, frame, gw, priority=priority)
         try:


### PR DESCRIPTION
## Summary
- ensure NetworkServer requests a Class C RX window as soon as the downlink scheduler returns a delivery time
- adjust Simulator to tolerate explicit Class C RX window timestamps while keeping the node listening state
- add a regression test covering Class C downlink delivery exactly at the scheduled instant

## Testing
- pytest tests/test_class_bc.py::test_class_c_downlink_delivered_at_scheduled_time

------
https://chatgpt.com/codex/tasks/task_e_68d8cd7a2a4c8331b86c5f0068096b7f