### PR TITLE
Retrait de la dégradation ADR1 et actualisation des tests FLoRa

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,9 +892,9 @@ Pour reproduire un scénario FLoRa :
    (`multipath_taps=3`), un seuil de détection fixé à `-110 dBm` et une fenêtre
    d'interférence minimale de `5 s`. Le délai réseau est également de 10 ms avec
    un traitement serveur de 1,2 s comme dans OMNeT++.
-2. Appliquez l'algorithme ADR1 via `from loraflexsim.launcher.adr_standard_1 import apply as adr1` puis `adr1(sim, degrade_channel=True, profile="flora")`.
-   Cette fonction reprend la logique du serveur FLoRa original tout en
-   remplaçant les canaux idéaux par des `AdvancedChannel` plus réalistes.
+2. Appliquez l'algorithme ADR1 via `from loraflexsim.launcher.adr_standard_1 import apply as adr1` puis `adr1(sim)`.
+   Depuis la version 1.1, la branche de « dégradation avancée » a été retirée :
+   le profil FLoRa utilise directement les canaux standards du simulateur.
 3. Spécifiez `adr_method="avg"` lors de la création du `Simulator` (ou sur
    `sim.network_server`) pour utiliser la moyenne des 20 derniers SNR.
 4. Fournissez le chemin du fichier INI à `Simulator(config_file=...)` ou
@@ -902,6 +902,10 @@ Pour reproduire un scénario FLoRa :
 5. Renseignez **Graine** pour conserver exactement le même placement et la même
    séquence d'intervalles d'une exécution à l'autre.
 6. Ou lancez `python examples/run_flora_example.py` qui combine ces réglages.
+
+> **Note de migration :** si vous utilisiez `adr1(..., degrade_channel=True, profile="flora", capture_mode="flora")`,
+> retirez ces arguments. Ils sont désormais ignorés et les canaux avancés ont
+> été supprimés au profit du modèle FLoRa standard.
 
 ### Compilation de FLoRa (OMNeT++)
 

--- a/examples/run_flora_example.py
+++ b/examples/run_flora_example.py
@@ -27,7 +27,7 @@ def run_example(*, steps: int = 1000, quiet: bool = False) -> Mapping[str, Any]:
         seed=1,
         adr_method="avg",
     )
-    adr1(sim, degrade_channel=True, profile="flora", capture_mode="flora")
+    adr1(sim)
     sim.run(steps)
     metrics = sim.get_metrics()
     if not quiet:

--- a/loraflexsim/launcher/adr_standard_1.py
+++ b/loraflexsim/launcher/adr_standard_1.py
@@ -1,76 +1,10 @@
 from __future__ import annotations
 
-import configparser
-from pathlib import Path
-
 from .simulator import Simulator
 from . import server
-from .advanced_channel import AdvancedChannel
 from .lorawan import TX_POWER_INDEX_TO_DBM
 from .channel import Channel
 from .gateway import FLORA_NON_ORTH_DELTA
-
-# ---------------------------------------------------------------------------
-# Channel degradation profiles.
-# Values common to all profiles are defined here while ``path_loss_exp`` and
-# ``shadowing_std`` are obtained from :data:`Channel.ENV_PRESETS`.
-# ---------------------------------------------------------------------------
-
-
-def _degrade_params(profile: str, capture_mode: str) -> dict:
-    """Return channel degradation parameters for ``profile``.
-
-    ``profile`` selects path loss and shadowing values from
-    :data:`Channel.ENV_PRESETS`.  Unknown profiles fall back to ``"flora"``.
-    Parameters ``variable_noise_std``, ``fine_fading_std``, ``fading`` and
-    ``rician_k`` can be overridden in a ``config.ini`` file under the ``[channel]``
-    section.
-    """
-
-    ple, shadow, *_ = Channel.ENV_PRESETS.get(
-        profile, Channel.ENV_PRESETS["flora"]
-    )
-
-    # Default degradation values tuned for a harsh radio environment
-    variable_noise_std = 20.0
-    fine_fading_std = 20.0
-    fading = "rayleigh"
-    rician_k = 0.0
-
-    # Override with values from config.ini when available.  Noise and fading
-    # standard deviations are intentionally kept high and therefore are not
-    # overridden by configuration values.
-    cp = configparser.ConfigParser()
-    cfg_path = Path(__file__).resolve().parents[2] / "config.ini"
-    cp.read(cfg_path)
-    if cp.has_section("channel"):
-        fading = cp.get("channel", "fading", fallback=fading)
-        if fading and fading.lower() == "none":
-            fading = None
-        rician_k = cp.getfloat("channel", "rician_k", fallback=rician_k)
-
-    if capture_mode == "advanced":
-        advanced_capture = True
-        flora_capture = False
-    else:
-        advanced_capture = False
-        flora_capture = True
-
-    return {
-        "propagation_model": "log_distance",  # or "cost231" with adjusted n
-        "fading": fading,  # or None
-        "rician_k": rician_k,
-        "path_loss_exp": ple,
-        "shadowing_std": shadow,
-        "variable_noise_std": variable_noise_std,
-        "fine_fading_std": fine_fading_std,
-        "freq_offset_std_hz": 1500.0,
-        "sync_offset_std_s": 0.005,
-        "advanced_capture": advanced_capture,
-        "flora_capture": flora_capture,
-        "flora_loss_model": "lognorm",
-        "capture_threshold_dB": 6.0,
-    }
 
 def apply(
     sim: Simulator,
@@ -86,16 +20,12 @@ def apply(
     sim : Simulator
         Instance to modify in-place.
     degrade_channel : bool, optional
-        If ``True``, replace existing :class:`~launcher.channel.Channel` objects
-        with :class:`~launcher.advanced_channel.AdvancedChannel` instances using
-        more realistic propagation impairments.
+        Paramètre conservé pour compatibilité. Depuis la version 1.1, il est
+        ignoré et n'altère plus les canaux radio existants.
     profile : str, optional
-        Environment key used to select ``path_loss_exp`` and ``shadowing_std``
-        from :data:`Channel.ENV_PRESETS`. Defaults to ``"flora"``.
+        Conservé pour compatibilité. Aucun effet depuis la version 1.1.
     capture_mode : str, optional
-        Selects which capture model to enable. ``"advanced"`` enables the
-        detailed capture effect while ``"flora"`` uses the simplified FLoRa
-        capture model. Defaults to ``"flora"``.
+        Conservé pour compatibilité. Aucun effet depuis la version 1.1.
     """
     # Marge ADR
     Simulator.MARGIN_DB = 15.0
@@ -123,52 +53,23 @@ def apply(
         node.adr_ack_limit = 64
         node.adr_ack_delay = 32
 
-    if not degrade_channel:
-        # Allow different SFs to interfere like in FLoRa
+    # Autorise l'interférence inter-SF comme dans FLoRa
+    for ch in sim.multichannel.channels:
+        ch.orthogonal_sf = False
+        ch.non_orth_delta = FLORA_NON_ORTH_DELTA
+
+    # Propager le comportement non orthogonal aux canaux des nœuds
+    for node in sim.nodes:
+        node.channel.orthogonal_sf = False
+        node.channel.non_orth_delta = FLORA_NON_ORTH_DELTA
+
+    # Pour les scénarios à SF fixe conserver un seuil très permissif pour
+    # coller au comportement historique
+    if getattr(sim, "fixed_sf", None) is not None:
         for ch in sim.multichannel.channels:
-            ch.orthogonal_sf = False
-            ch.non_orth_delta = FLORA_NON_ORTH_DELTA
-        # Propagate the non-orthogonal behaviour to existing node channels
-        for node in sim.nodes:
-            node.channel.orthogonal_sf = False
-            node.channel.non_orth_delta = FLORA_NON_ORTH_DELTA
-        # For fixed spreading factor scenarios keep a very permissive
-        # detection threshold to mirror the original behaviour
-        if getattr(sim, "fixed_sf", None) is not None:
-            for ch in sim.multichannel.channels:
-                ch.detection_threshold_dBm = -float("inf")
+            ch.detection_threshold_dBm = -float("inf")
 
-    if degrade_channel:
-        new_channels = []
-        base_params = _degrade_params(profile, capture_mode)
-        for ch in sim.multichannel.channels:
-            params = dict(base_params)
-            # Conserver les paramètres spécifiques au canal original
-            params["frequency_hz"] = ch.frequency_hz
-            if hasattr(ch, "bandwidth"):
-                params["bandwidth"] = ch.bandwidth
-            if hasattr(ch, "coding_rate"):
-                params["coding_rate"] = ch.coding_rate
-            sf = 12
-            bw = params.get("bandwidth", 125000)
-            params["sensitivity_margin_dB"] = getattr(ch, "sensitivity_margin_dB", 0.0)
-            # Créer un canal avancé avec les paramètres mis à jour
-            adv = AdvancedChannel(**params)
-            adv.orthogonal_sf = False
-            adv.non_orth_delta = FLORA_NON_ORTH_DELTA
-            new_channels.append(adv)
-
-        # Remplacer la liste des canaux par les nouveaux canaux dégradés
-        sim.multichannel.channels = new_channels
-        sim.channel = sim.multichannel.channels[0]
-        sim.network_server.channel = sim.channel
-        # Mettre à jour la référence de canal de chaque nœud
-        for node in sim.nodes:
-            node.channel = sim.multichannel.select_mask(getattr(node, "chmask", 0xFFFF))
-            node.channel.orthogonal_sf = False
-            node.channel.non_orth_delta = FLORA_NON_ORTH_DELTA
-
-    # Ensure server and first channel reflect the non-orthogonal setting
+    # S'assurer que le serveur et le canal principal reflètent les réglages
     sim.channel = sim.multichannel.channels[0]
     sim.channel.orthogonal_sf = False
     sim.channel.non_orth_delta = FLORA_NON_ORTH_DELTA

--- a/loraflexsim/launcher/dashboard.py
+++ b/loraflexsim/launcher/dashboard.py
@@ -655,10 +655,7 @@ def select_adr(module, name: str) -> None:
     if adr_select.value != name:
         adr_select.value = name
     if sim is not None:
-        if module is adr_standard_1:
-            module.apply(sim, degrade_channel=True, profile="flora")
-        else:
-            module.apply(sim)
+        module.apply(sim)
 
 # --- Callback chrono ---
 def periodic_chrono_update():
@@ -863,10 +860,7 @@ def setup_simulation(seed_offset: int = 0):
 
     # Appliquer le profil ADR sélectionné
     if selected_adr_module:
-        if selected_adr_module is adr_standard_1:
-            selected_adr_module.apply(sim, degrade_channel=True, profile="flora")
-        else:
-            selected_adr_module.apply(sim)
+        selected_adr_module.apply(sim)
 
     # La mobilité est désormais gérée directement par le simulateur
     start_time = time.time()

--- a/tests/test_adr_standard_advanced.py
+++ b/tests/test_adr_standard_advanced.py
@@ -1,16 +1,12 @@
-import configparser
-from os import PathLike
-
 import pytest
 
 from loraflexsim.launcher import adr_standard_1
-from loraflexsim.launcher.advanced_channel import AdvancedChannel
 from loraflexsim.launcher.channel import Channel
 from loraflexsim.launcher.gateway import FLORA_NON_ORTH_DELTA
 from loraflexsim.launcher.simulator import Simulator
 
 
-def test_advanced_degradation_uses_advanced_capture_and_thresholds():
+def test_apply_preserves_base_channel_with_degrade_flag():
     base_channel = Channel(bandwidth=125_000, sensitivity_margin_dB=2.5)
     sim = Simulator(num_nodes=1, packets_to_send=0, channels=[base_channel])
 
@@ -21,11 +17,11 @@ def test_advanced_degradation_uses_advanced_capture_and_thresholds():
         capture_mode="advanced",
     )
 
-    assert sim.multichannel.channels, "La dégradation doit produire au moins un canal."
+    assert sim.multichannel.channels, "un canal doit être disponible"
     for channel in sim.multichannel.channels:
-        assert isinstance(channel, AdvancedChannel)
-        assert channel.advanced_capture is True
-        assert channel.flora_capture is False
+        assert isinstance(channel, Channel)
+        assert channel.orthogonal_sf is False
+        assert channel.non_orth_delta == FLORA_NON_ORTH_DELTA
         expected_threshold = Channel.flora_detection_threshold(12, channel.bandwidth)
         expected_threshold += channel.sensitivity_margin_dB
         assert channel.detection_threshold(12) == expected_threshold
@@ -34,45 +30,25 @@ def test_advanced_degradation_uses_advanced_capture_and_thresholds():
     assert sim.channel.orthogonal_sf is False
     assert sim.channel.non_orth_delta == FLORA_NON_ORTH_DELTA
     assert sim.network_server.channel is sim.channel
-    assert sim.network_server.channel.orthogonal_sf is False
-    assert sim.network_server.channel.non_orth_delta == FLORA_NON_ORTH_DELTA
 
 
-def test_advanced_degradation_reads_channel_overrides(monkeypatch):
-    base_channel = Channel(bandwidth=125_000)
-    sim = Simulator(num_nodes=1, packets_to_send=0, channels=[base_channel])
-
-    fake_config = """[channel]
-    fading=none
-    rician_k=4.2
-    """
-
-    original_read = configparser.ConfigParser.read
-
-    def fake_read(self, filenames, encoding=None):
-        if isinstance(filenames, (str, PathLike)):
-            path = str(filenames)
-            if path.endswith("config.ini"):
-                self.read_string(fake_config)
-                return [path]
-            return original_read(self, filenames, encoding=encoding)
-        if isinstance(filenames, (list, tuple)):
-            read_files: list[str] = []
-            for entry in filenames:
-                read_files.extend(fake_read(self, entry, encoding=encoding))
-            return read_files
-        return original_read(self, filenames, encoding=encoding)
-
-    monkeypatch.setattr(configparser.ConfigParser, "read", fake_read)
+def test_profile_and_capture_parameters_are_ignored():
+    custom_channel = Channel(
+        bandwidth=125_000,
+        path_loss_exp=3.1,
+        shadowing_std=1.7,
+        sensitivity_margin_dB=1.0,
+    )
+    sim = Simulator(num_nodes=1, packets_to_send=0, channels=[custom_channel])
 
     adr_standard_1.apply(
         sim,
         degrade_channel=True,
-        profile="flora",
+        profile="urban",
         capture_mode="advanced",
     )
 
-    for channel in sim.multichannel.channels:
-        assert isinstance(channel, AdvancedChannel)
-        assert channel.fading is None
-        assert channel.rician_k == pytest.approx(4.2)
+    configured = sim.multichannel.channels[0]
+    assert configured.path_loss_exp == pytest.approx(3.1)
+    assert configured.shadowing_std == pytest.approx(1.7)
+    assert configured.sensitivity_margin_dB == pytest.approx(1.0)

--- a/tests/test_detection_threshold.py
+++ b/tests/test_detection_threshold.py
@@ -5,7 +5,7 @@ from loraflexsim.launcher.channel import Channel
 
 def test_apply_sets_flora_detection_threshold():
     sim = Simulator(num_nodes=1, packets_to_send=0)
-    adr_standard_1.apply(sim, degrade_channel=True, profile="flora")
+    adr_standard_1.apply(sim)
     node = sim.nodes[0]
     expected = Channel.FLORA_SENSITIVITY[node.sf][int(node.channel.bandwidth)]
     assert node.channel.detection_threshold(node.sf) == expected

--- a/tests/test_flora_sca.py
+++ b/tests/test_flora_sca.py
@@ -21,25 +21,29 @@ CONFIG = "flora-master/simulations/examples/n100-gw1.ini"
 def test_flora_sca_compare():
     sca = Path(__file__).parent / "data" / "n100_gw1_expected.sca"
     sim = Simulator(flora_mode=True, config_file=CONFIG, seed=1, adr_method="avg")
-    adr1(sim, degrade_channel=True, profile="flora", capture_mode="flora")
+    adr1(sim)
     sim.run(1000)
     metrics = sim.get_metrics()
 
     load_flora_metrics(sca)
-    load_flora_rx_stats(sca)  # ensure parser works
+    flora_rx = load_flora_rx_stats(sca)
 
     assert compare_with_sim(metrics, sca, pdr_tol=0.01)
+    snr_values = [snr for snr in sim.network_server.event_snir.values() if snr is not None]
+    assert snr_values, "aucune mesure SNR enregistrée"
+    avg_snr = sum(snr_values) / len(snr_values)
+    assert abs(avg_snr - flora_rx["snr"]) <= 0.5
 
 
 @pytest.mark.slow
 def test_flora_sca_quantization_trace():
     sim = Simulator(flora_mode=True, config_file=CONFIG, seed=1, adr_method="avg")
-    adr1(sim, degrade_channel=True, profile="flora", capture_mode="flora")
+    adr1(sim)
     sim.run(1000)
     sim_q = Simulator(
         flora_mode=True, config_file=CONFIG, seed=1, adr_method="avg", tick_ns=1
     )
-    adr1(sim_q, degrade_channel=True, profile="flora", capture_mode="flora")
+    adr1(sim_q)
     sim_q.run(1000)
 
     def to_ns(log_map):


### PR DESCRIPTION
## Résumé
- neutraliser l'option `degrade_channel` d'ADR1 et simplifier son intégration dans le tableau de bord et l'exemple FLoRa
- mettre à jour la documentation FLoRa et ajouter une note de migration concernant la suppression de la dégradation avancée
- adapter la batterie de tests FLoRa pour refléter le nouveau comportement (comparaison SNR comprise)

## Tests
- `pytest tests/test_detection_threshold.py tests/test_degraded_channel_interval.py tests/test_adr_standard_advanced.py`
- `pytest tests/test_flora_sca.py -k compare --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_68d8d41205ac83319520e31416d4021d