### PR TITLE
Initialise la table PDR avant les callbacks de simulation

### DIFF
--- a/loraflexsim/launcher/dashboard.py
+++ b/loraflexsim/launcher/dashboard.py
@@ -885,6 +885,8 @@ def setup_simulation(seed_offset: int = 0):
     # La mobilité est désormais gérée directement par le simulateur
     start_time = time.time()
     max_real_time = real_time_duration_input.value if real_time_duration_input.value > 0 else None
+    pdr_table.object = pd.DataFrame(columns=["Node", "PDR", "Recent PDR"])
+
     chrono_callback = pn.state.add_periodic_callback(periodic_chrono_update, period=100, timeout=None)
 
     initial_metrics = sim.get_metrics()


### PR DESCRIPTION
## Summary
- initialise pdr_table.object avec un DataFrame vide contenant les colonnes attendues avant le démarrage des callbacks périodiques

## Testing
- pytest tests/test_dashboard_step.py
- pytest tests/test_dashboard_pause.py

------
https://chatgpt.com/codex/tasks/task_e_68d906d270fc8331a3812effe5f65000