### PR TITLE
Handle non-positive beacon lookup

### DIFF
--- a/loraflexsim/launcher/lorawan.py
+++ b/loraflexsim/launcher/lorawan.py
@@ -835,6 +835,8 @@ def next_beacon_time(
     import math
 
     if last_beacon is None:
+        if after_time <= 0.0:
+            return 0.0
         return math.ceil((after_time + 1e-9) / beacon_interval) * beacon_interval
 
     interval = beacon_interval * (1.0 + drift)


### PR DESCRIPTION
## Summary
- return 0 when requesting the next beacon before or at the reference time
- keep the existing calculation for later beacon lookups

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d90ee3c5dc8331b7e9c9a13a0932a8