### PR TITLE
Extend DR to SF mapping for RX2 data rates

### DIFF
--- a/loraflexsim/launcher/lorawan.py
+++ b/loraflexsim/launcher/lorawan.py
@@ -19,8 +19,22 @@ class LoRaWANFrame:
 # LoRaWAN ADR MAC commands (simplified)
 # ---------------------------------------------------------------------------
 
-DR_TO_SF = {0: 12, 1: 11, 2: 10, 3: 9, 4: 8, 5: 7}
-SF_TO_DR = {sf: dr for dr, sf in DR_TO_SF.items()}
+DR_TO_SF = {
+    0: 12,
+    1: 11,
+    2: 10,
+    3: 9,
+    4: 8,
+    5: 7,
+    6: 7,
+    8: 12,
+    9: 11,
+    10: 10,
+    11: 9,
+    12: 8,
+    13: 7,
+}
+SF_TO_DR = {sf: dr for dr, sf in sorted(DR_TO_SF.items(), reverse=True)}
 # Default RX2 (and ping-slot) data rate per LoRaWAN region
 REGION_DEFAULT_RX2_DR = {
     "EU868": 3,


### PR DESCRIPTION
## Summary
- extend the DR→SF mapping with DR6 and DR8–DR13 and derive SF→DR accordingly
- add a Class B/C scheduler regression test covering the US915/AU915 RX2 data rate

## Testing
- pytest tests/test_class_bc.py::test_class_bc_us915_rx2_spreading_factor

------
https://chatgpt.com/codex/tasks/task_e_68d9194fed148331b9a9950ec68f54e5