### PR TITLE
Validate Channel.path_loss distance handling

### DIFF
--- a/loraflexsim/launcher/channel.py
+++ b/loraflexsim/launcher/channel.py
@@ -752,10 +752,10 @@ class Channel:
 
     def path_loss(self, distance: float) -> float:
         """Calcule la perte de parcours (en dB) pour une distance donnée (m)."""
+        if distance <= 0:
+            raise ValueError("distance must be > 0")
         if self.omnet_phy:
             return self.omnet_phy.path_loss(distance)
-        if distance <= 0:
-            return 0.0
         if self.propagation_cache is not None:
             return self.propagation_cache.get(
                 distance, lambda: self._path_loss_uncached(distance)

--- a/tests/test_channel_path_loss_validation.py
+++ b/tests/test_channel_path_loss_validation.py
@@ -1,6 +1,6 @@
 import pytest
 
-from loraflexsim.launcher.channel import path_loss_hata_okumura, path_loss_oulu
+from loraflexsim.launcher.channel import Channel, path_loss_hata_okumura, path_loss_oulu
 
 def test_hata_okumura_rejects_non_positive_distance():
     with pytest.raises(ValueError):
@@ -13,3 +13,11 @@ def test_oulu_rejects_non_positive_distance():
         path_loss_oulu(0.0, 128.95, 2.32, 1000.0, 2.0)
     with pytest.raises(ValueError):
         path_loss_oulu(-5.0, 128.95, 2.32, 1000.0, 2.0)
+
+
+def test_channel_path_loss_rejects_non_positive_distance():
+    channel = Channel()
+    with pytest.raises(ValueError):
+        channel.path_loss(0.0)
+    with pytest.raises(ValueError):
+        channel.path_loss(-2.0)


### PR DESCRIPTION
## Summary
- raise a ValueError from `Channel.path_loss` when the distance is non-positive to align with other path loss helpers
- extend the path loss validation tests to cover the `Channel` method

## Testing
- `pytest tests/test_channel_path_loss_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68d9212657d083318234af3d10382a4d