### PR TITLE
Fix math import grouping in mobility launchers

### DIFF
--- a/loraflexsim/launcher/gauss_markov.py
+++ b/loraflexsim/launcher/gauss_markov.py
@@ -1,4 +1,5 @@
 import math
+
 import numpy as np
 
 from ._random import SeedLike, ensure_rng

--- a/loraflexsim/launcher/smooth_mobility.py
+++ b/loraflexsim/launcher/smooth_mobility.py
@@ -1,4 +1,5 @@
 import math
+
 import numpy as np
 
 from ._random import SeedLike, ensure_rng


### PR DESCRIPTION
## Summary
- ensure the mobility launchers import the math module explicitly before numpy

## Testing
- `pytest -k "channel"` *(fails: multiple validation scenarios exceed PDR tolerances; pandas missing for plotting helper)*
- `pytest -k "lorawan"`
- `pytest -k "mobility"` *(fails: validation scenarios exceed PDR tolerance; pandas stub lacks read_csv)*
- `pytest -k "gateway"` *(fails: gateway SNIR samples not recorded)*
- `pytest -k "omnet_phy or rx_chain or overlap_snir or flora_capture or startup_currents or pa_ramp"` *(fails: pandas required for flora metrics)*

------
https://chatgpt.com/codex/tasks/task_e_68d937588b408331b7985409697d2d1a