### PR TITLE
Align ADR nstep handling with FLoRa

### DIFF
--- a/loraflexsim/launcher/server.py
+++ b/loraflexsim/launcher/server.py
@@ -885,8 +885,6 @@ class NetworkServer:
                         while nstep < 0 and p_idx > 0:
                             p_idx -= 1
                             nstep += 1
-                        if nstep < 0 and p_idx == 0:
-                            nstep = 0
                         while nstep < 0 and sf < 12:
                             sf += 1
                             nstep += 1
@@ -970,8 +968,6 @@ class NetworkServer:
                     while nstep < 0 and p_idx > 0:
                         p_idx -= 1
                         nstep += 1
-                    if nstep < 0 and p_idx == 0:
-                        nstep = 0
                     while nstep < 0 and sf < 12:
                         sf += 1
                         nstep += 1


### PR DESCRIPTION
## Summary
- remove the forced reset of `nstep` when the power index is already at its minimum so that the remaining steps continue to raise the spreading factor
- apply the same handling to both `adr-max` and the default ADR branch to match the FLoRa algorithm

## Testing
- `pytest loraflexsim/tests/test_flora_trace_alignment.py tests/integration/test_validation_matrix.py -k adr` *(fails: ADR reference tests still report missing commands under the default energy detection threshold)*

------
https://chatgpt.com/codex/tasks/task_e_68d94279c76c8331a142f9e3dc625105