### PR TITLE
Fix gateway overlap detection start time

### DIFF
--- a/loraflexsim/launcher/gateway.py
+++ b/loraflexsim/launcher/gateway.py
@@ -186,7 +186,11 @@ class Gateway:
         for t in concurrent_transmissions:
             if orthogonal_sf and t.get('sf') != sf:
                 continue
-            overlap = min(t['end_time'], end_time) - current_time
+            # Le chevauchement effectif démarre lorsque les deux transmissions
+            # sont actives; on ignore donc le temps avant le début réel de l'autre
+            # paquet pour éviter de fausses collisions/captures.
+            overlap_start = max(t['start_time'], current_time)
+            overlap = min(t['end_time'], end_time) - overlap_start
             if overlap > min_interference_time:
                 interfering_transmissions.append(t)
 


### PR DESCRIPTION
## Summary
- compute interference overlap using the effective start time for concurrent transmissions in the gateway
- document the rationale to avoid spurious collision or capture detections

## Testing
- pytest tests/test_collision_capture.py tests/test_gateway_capture.py

------
https://chatgpt.com/codex/tasks/task_e_68d97e8937a8833198c11e1116e7e322