### PR TITLE
Add DutyCycleAns response and enqueue in node handling

### DIFF
--- a/loraflexsim/launcher/lorawan.py
+++ b/loraflexsim/launcher/lorawan.py
@@ -176,6 +176,20 @@ class DutyCycleReq:
 
 
 @dataclass
+class DutyCycleAns:
+    """Acknowledge a DutyCycleReq."""
+
+    def to_bytes(self) -> bytes:
+        return bytes([0x04])
+
+    @staticmethod
+    def from_bytes(data: bytes) -> "DutyCycleAns":
+        if len(data) < 1 or data[0] != 0x04:
+            raise ValueError("Invalid DutyCycleAns")
+        return DutyCycleAns()
+
+
+@dataclass
 class RXParamSetupReq:
     rx1_dr_offset: int
     rx2_datarate: int

--- a/loraflexsim/launcher/node.py
+++ b/loraflexsim/launcher/node.py
@@ -716,6 +716,7 @@ class Node:
             DeviceTimeReq,
             DeviceTimeAns,
             DutyCycleReq,
+            DutyCycleAns,
             RXParamSetupReq,
             RXParamSetupAns,
             RXTimingSetupReq,
@@ -801,13 +802,12 @@ class Node:
                 self.pending_mac_cmd = DeviceTimeAns(int(self.fcnt_up)).to_bytes()
             elif len(payload) >= 2 and payload[0] == 0x04:
                 try:
-                    from .lorawan import DutyCycleReq
-
                     req = DutyCycleReq.from_bytes(payload[:2])
                     self.max_duty_cycle = req.max_duty_cycle
                     simulator = getattr(self, "simulator", None)
                     if simulator is not None and hasattr(simulator, "update_duty_cycle"):
                         simulator.update_duty_cycle(self.id, self.max_duty_cycle)
+                    self.pending_mac_cmd = DutyCycleAns().to_bytes()
                 except Exception:
                     pass
             elif len(payload) >= 5 and payload[0] == 0x05:


### PR DESCRIPTION
## Summary
- add a DutyCycleAns dataclass mirroring the existing MAC response helpers
- enqueue a DutyCycleAns reply when nodes process a DutyCycleReq downlink

## Testing
- pytest tests/test_node_mac_commands.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d981079d408331bc15ed4212218665