### PR TITLE
Fix neutral cell handling in path mobility

### DIFF
--- a/loraflexsim/launcher/path_mobility.py
+++ b/loraflexsim/launcher/path_mobility.py
@@ -72,8 +72,10 @@ class PathMobility:
 
     def _speed_factor_cell(self, cx: int, cy: int) -> float:
         val = float(self.path_map[cy][cx])
-        if val <= 0:
+        if val < 0:
             return float("inf")
+        if val == 0:
+            return 1.0
         return 1.0 / val
 
     def _update_dynamic_obstacles(self, dt: float) -> None:


### PR DESCRIPTION
## Summary
- adjust the speed factor so neutral cells (0) remain traversable while obstacles (negative) keep infinite cost

## Testing
- pytest tests/test_path_mobility.py tests/test_mobility_extra.py

------
https://chatgpt.com/codex/tasks/task_e_68d9811abca0833193fb854cecea634f