### PR TITLE
Franciser le libellé d'interférence minimale dans le tableau de bord

### DIFF
--- a/loraflexsim/launcher/dashboard.py
+++ b/loraflexsim/launcher/dashboard.py
@@ -311,7 +311,7 @@ detection_threshold_input = pn.widgets.FloatInput(
 )
 detection_threshold_input.disabled = True
 min_interference_input = pn.widgets.FloatInput(
-    name="Min interference (s)", value=5.0, step=0.1, start=0.0
+    name="Interférence minimale (s)", value=5.0, step=0.1, start=0.0
 )
 # Pas de champ dédié pour le délai minimal avant le premier envoi
 min_interference_input.disabled = True


### PR DESCRIPTION
## Résumé
- francisation du libellé du champ `min_interference_input` dans le tableau de bord Panel

## Tests
- panel serve loraflexsim/launcher/dashboard.py --show

------
https://chatgpt.com/codex/tasks/task_e_68d98f76475c8331bb74826dc2a81bf5