### PR TITLE
Optimize metrics timeline updates for dashboard

### DIFF
--- a/loraflexsim/launcher/simulator.py
+++ b/loraflexsim/launcher/simulator.py
@@ -2073,6 +2073,13 @@ class Simulator:
         }
         self.metrics_timeline.append(snapshot)
 
+    def get_latest_metrics_snapshot(self) -> dict[str, float | int] | None:
+        """Retourne une copie du dernier point de la timeline des métriques."""
+
+        if not self.metrics_timeline:
+            return None
+        return dict(self.metrics_timeline[-1])
+
     def get_metrics(self) -> dict:
         """Retourne un dictionnaire des métriques actuelles de la simulation."""
         total_sent = self.tx_attempted


### PR DESCRIPTION
## Summary
- add `Simulator.get_latest_metrics_snapshot` to expose the most recent timeline entry without rebuilding dataframes
- update dashboard metrics timeline handling to refresh incrementally and only rebuild plots periodically
- extend dashboard step tests with incremental refresh coverage and adjusted expectations

## Testing
- pytest -k "dashboard and step_simulation"

------
https://chatgpt.com/codex/tasks/task_e_68d999f773a08331bda5226fa010460b