### PR TITLE
Retirer la comparaison FLoRa du tableau de bord

### DIFF
--- a/loraflexsim/launcher/dashboard.py
+++ b/loraflexsim/launcher/dashboard.py
@@ -74,7 +74,6 @@ pause_prev_disabled = False
 node_paths: dict[int, list[tuple[float, float]]] = {}
 _latest_global_counters: tuple[int, int] | None = None
 _last_metrics_counters: tuple[int, int] | None = None
-flora_metrics: dict[str, float] | None = None
 
 
 def _get_last_metrics_timeline() -> pd.DataFrame | list[dict] | None:
@@ -443,13 +442,6 @@ fast_forward_progress = pn.indicators.Progress(name="Avancement", value=0, width
 pdr_table = pn.pane.DataFrame(
     pd.DataFrame(columns=["Node", "PDR", "Recent PDR"]),
     height=200,
-    width=220,
-)
-
-# Tableau de comparaison avec FLoRa (référence historique)
-flora_compare_table = pn.pane.DataFrame(
-    pd.DataFrame(columns=["Metric", "FLoRa", "SFRD", "Diff"]),
-    height=180,
     width=220,
 )
 
@@ -1045,30 +1037,6 @@ def step_simulation():
         pdr_table.object = table_df
         update_histogram(metrics)
 
-    if flora_metrics:
-        source_metrics: dict[str, float]
-        if metrics is not None:
-            source_metrics = metrics
-        elif isinstance(merged_metrics, dict):
-            source_metrics = merged_metrics
-        else:
-            source_metrics = {}
-
-        metrics_rows: list[dict[str, float | str]] = []
-        metrics_keys = ["PDR", "collisions", "throughput_bps", "energy_J"]
-        for key in metrics_keys:
-            flora_val = float(flora_metrics.get(key, 0.0) or 0.0)
-            sim_val = float(source_metrics.get(key, 0.0) or 0.0)
-            metrics_rows.append(
-                {
-                    "Metric": key,
-                    "FLoRa": flora_val,
-                    "SFRD": sim_val,
-                    "Diff": sim_val - flora_val,
-                }
-            )
-        flora_compare_table.object = pd.DataFrame(metrics_rows)
-
     snapshot_added = False
     if has_new_snapshot and snapshot_copy is not None:
         run_timeline.append(snapshot_copy)
@@ -1277,10 +1245,6 @@ def setup_simulation(seed_offset: int = 0):
     start_time = time.time()
     max_real_time = real_time_duration_input.value if real_time_duration_input.value > 0 else None
     pdr_table.object = pd.DataFrame(columns=["Node", "PDR", "Recent PDR"])
-    flora_compare_table.object = pd.DataFrame(
-        columns=["Metric", "FLoRa", "SFRD", "Diff"]
-    )
-
     chrono_callback = pn.state.add_periodic_callback(periodic_chrono_update, period=100, timeout=None)
 
     initial_metrics = sim.get_metrics()
@@ -1921,7 +1885,6 @@ metrics_col = pn.Column(
     throughput_indicator,
     retrans_indicator,
     pdr_table,
-    flora_compare_table,
 )
 metrics_col.width = 220
 


### PR DESCRIPTION
## Summary
- retirer la variable globale et le tableau Panel dédiés à la comparaison FLoRa
- supprimer toute mise à jour ou réinitialisation du tableau lors de l’exécution et de la configuration de la simulation
- ajuster la colonne des métriques pour ne conserver que les indicateurs actifs

## Testing
- non testé (environnement non interactif)


------
https://chatgpt.com/codex/tasks/task_e_68da6a6e1b3c83318114d1eccca6ee2f