### PR TITLE
Fix Command params default factory and extend API tests

### DIFF
--- a/loraflexsim/launcher/web_api.py
+++ b/loraflexsim/launcher/web_api.py
@@ -4,7 +4,7 @@ import asyncio
 from typing import Any, Dict, Set
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .simulator import Simulator
 
@@ -17,7 +17,7 @@ _subscribers: Set[WebSocket] = set()
 
 class Command(BaseModel):
     command: str
-    params: Dict[str, Any] = {}
+    params: Dict[str, Any] = Field(default_factory=dict)
 
 
 async def _broadcast(event: str, data: Dict[str, Any] | None = None) -> None:

--- a/tests/test_rest_api_gap.py
+++ b/tests/test_rest_api_gap.py
@@ -43,8 +43,13 @@ def test_rest_api_status_endpoint_lifecycle() -> None:
             assert initial_payload["status"] == "idle"
             assert initial_payload["metrics"] == {}
 
-            start_payload = web_api.Command(command="start_sim", params={})
-            start_response = await web_api.start_simulation(start_payload)
+            first_payload = web_api.Command(command="start_sim", params={})
+            first_payload.params["custom"] = "value"
+
+            second_payload = web_api.Command(command="start_sim")
+            assert second_payload.params == {}
+
+            start_response = await web_api.start_simulation(second_payload)
             assert start_response["status"] == "started"
 
             await asyncio.sleep(0)


### PR DESCRIPTION
## Summary
- ensure the REST API Command model uses a default factory for its params mapping
- extend the REST API lifecycle test to verify new Command instances start with an empty params dict

## Testing
- pytest tests/test_rest_api_gap.py

------
https://chatgpt.com/codex/tasks/task_e_68da7ff1f26c833194e518d898e5e6e9