### PR TITLE
Fix CMAC handling of empty messages

### DIFF
--- a/loraflexsim/launcher/crypto.py
+++ b/loraflexsim/launcher/crypto.py
@@ -249,7 +249,7 @@ def cmac(key: bytes, msg: bytes) -> bytes:
     n = (len(msg) + 15) // 16
     if n == 0:
         n = 1
-    complete = len(msg) % 16 == 0
+    complete = len(msg) != 0 and len(msg) % 16 == 0
     last = msg[(n - 1) * 16 :]
     if complete:
         last = bytes(x ^ y for x, y in zip(last, K1))

--- a/tests/test_lorawan_mic.py
+++ b/tests/test_lorawan_mic.py
@@ -1,0 +1,9 @@
+from loraflexsim.launcher.crypto import cmac
+
+
+def test_cmac_empty_message_matches_rfc4493_vector():
+    """La RFC 4493 Section 4 fournit la valeur de référence du CMAC pour un message vide."""
+    key = bytes.fromhex("2b7e151628aed2a6abf7158809cf4f3c")
+    expected = bytes.fromhex("bb1d6929e95937287fa37d129b756746")
+
+    assert cmac(key, b"") == expected


### PR DESCRIPTION
## Summary
- ensure CMAC treats empty messages as incomplete blocks per RFC 4493
- add a unit test that checks the empty-message MIC against the RFC reference vector

## Testing
- pytest tests/test_lorawan_mic.py

------
https://chatgpt.com/codex/tasks/task_e_68da83f964ac833196d0808f11a71f16