### PR TITLE
Support capture matrix file paths in gateway start_reception

### DIFF
--- a/loraflexsim/launcher/gateway.py
+++ b/loraflexsim/launcher/gateway.py
@@ -1,5 +1,6 @@
 import logging
 import math
+from os import PathLike
 
 from .non_orth_delta import (
     DEFAULT_NON_ORTH_DELTA as FLORA_NON_ORTH_DELTA,
@@ -159,6 +160,9 @@ class Gateway:
             ΔRSSI (dB) minimal entre ``SF_signal`` (ligne) et
             ``SF_interférence`` (colonne) pour autoriser la capture.
         """
+        if isinstance(non_orth_delta, (str, PathLike)):
+            non_orth_delta = load_non_orth_delta(str(non_orth_delta))
+
         if rssi < getattr(self, "energy_detection_dBm", -float("inf")):
             logger.debug(
                 "Gateway %s: ignore un paquet sous le seuil d'énergie (RSSI=%.1f dBm)",

--- a/tests/test_gateway_capture.py
+++ b/tests/test_gateway_capture.py
@@ -263,6 +263,46 @@ def test_non_orth_multi_sf_capture_respects_matrix_and_preamble():
         assert server.packets_received == 1
 
 
+def test_non_orth_delta_loaded_from_path(tmp_path):
+    matrix = [[10.0] * 6 for _ in range(6)]
+    matrix_path = tmp_path / "matrix.json"
+    matrix_path.write_text(json.dumps(matrix), encoding="utf8")
+
+    gw = Gateway(0, 0, 0)
+    server = NetworkServer()
+    server.gateways = [gw]
+
+    gw.start_reception(
+        1,
+        1,
+        7,
+        -50,
+        1.0,
+        6.0,
+        0.0,
+        868e6,
+        orthogonal_sf=False,
+        non_orth_delta=str(matrix_path),
+    )
+    gw.start_reception(
+        2,
+        2,
+        9,
+        -58,
+        1.0,
+        6.0,
+        0.0,
+        868e6,
+        orthogonal_sf=False,
+        non_orth_delta=str(matrix_path),
+    )
+
+    gw.end_reception(1, server, 1)
+    gw.end_reception(2, server, 2)
+
+    assert server.packets_received == 0
+
+
 def test_non_orth_capture_blocked_by_contaminated_preamble():
     gw = Gateway(0, 0, 0)
     server = NetworkServer()


### PR DESCRIPTION
## Summary
- detect string and path inputs for the non-orthogonal capture matrix and load them before threshold calculations
- add a regression test to ensure collisions use matrices loaded from file paths

## Testing
- pytest tests/test_gateway_capture.py::test_non_orth_delta_loaded_from_path

------
https://chatgpt.com/codex/tasks/task_e_68da86043e3c83319632db7454b8f422