### PR TITLE
Corrige l'utilisation de StaticText pour le badge ADR

### DIFF
--- a/loraflexsim/launcher/dashboard.py
+++ b/loraflexsim/launcher/dashboard.py
@@ -226,7 +226,7 @@ adr_server_checkbox = pn.widgets.Checkbox(name="ADR serveur", value=True)
 adr1_button = pn.widgets.Button(name="ADR 1", button_type="default")
 adr2_button = pn.widgets.Button(name="ADR 2", button_type="default")
 adr3_button = pn.widgets.Button(name="ADR_ML", button_type="default")
-active_adr_badge = pn.widgets.StaticText(name="ADR actif", value=_DEFAULT_ADR_NAME)
+active_adr_badge = pn.indicators.StaticText(name="ADR actif", value=_DEFAULT_ADR_NAME)
 
 _ADR_BUTTONS = {
     "ADR 1": adr1_button,

--- a/tests/test_dashboard_step.py
+++ b/tests/test_dashboard_step.py
@@ -86,6 +86,7 @@ def _install_panel_stub():
     indicators_module = types.ModuleType("panel.indicators")
     indicators_module.Number = _DummyWidget
     indicators_module.Progress = _DummyWidget
+    indicators_module.StaticText = _DummyWidget
 
     pane_module = types.ModuleType("panel.pane")
     pane_module.HTML = _DummyPane


### PR DESCRIPTION
## Résumé
- remplace le widget StaticText du badge ADR par la version disponible dans panel.indicators
- met à jour le stub Panel de la suite de tests pour exposer panel.indicators.StaticText

## Tests
- `pytest tests/test_dashboard_step.py::test_step_simulation_updates_indicators -q` *(échec : l'attribut `update_timeline` manque dans le module dashboard actuel)*

------
https://chatgpt.com/codex/tasks/task_e_68dabac8dd3483318c2be26c64d0c5db