### PR TITLE
Utiliser pn.widgets.StaticText pour le badge ADR

### DIFF
--- a/loraflexsim/launcher/dashboard.py
+++ b/loraflexsim/launcher/dashboard.py
@@ -226,7 +226,7 @@ adr_server_checkbox = pn.widgets.Checkbox(name="ADR serveur", value=True)
 adr1_button = pn.widgets.Button(name="ADR 1", button_type="default")
 adr2_button = pn.widgets.Button(name="ADR 2", button_type="default")
 adr3_button = pn.widgets.Button(name="ADR_ML", button_type="default")
-active_adr_badge = pn.indicators.StaticText(name="ADR actif", value=_DEFAULT_ADR_NAME)
+active_adr_badge = pn.widgets.StaticText(name="ADR actif", value=_DEFAULT_ADR_NAME)
 
 _ADR_BUTTONS = {
     "ADR 1": adr1_button,

--- a/tests/test_dashboard_step.py
+++ b/tests/test_dashboard_step.py
@@ -80,13 +80,14 @@ def _install_panel_stub():
         "Button",
         "Toggle",
         "TextAreaInput",
+        "StaticText",
     ]:
         setattr(widgets_module, widget_name, _DummyWidget)
 
     indicators_module = types.ModuleType("panel.indicators")
     indicators_module.Number = _DummyWidget
     indicators_module.Progress = _DummyWidget
-    indicators_module.StaticText = _DummyWidget
+    indicators_module.StaticText = widgets_module.StaticText
 
     pane_module = types.ModuleType("panel.pane")
     pane_module.HTML = _DummyPane


### PR DESCRIPTION
## Summary
- instantiates the ADR status badge with `pn.widgets.StaticText`
- updates the Panel test stub so `StaticText` is exposed from `panel.widgets` while keeping the indicator alias

## Testing
- python -m panel serve dashboard.py --show *(fails: AttributeError: module '_random' has no attribute 'Random')*
- pytest tests/test_dashboard_step.py *(fails: AttributeError: <module 'loraflexsim.launcher.dashboard' ...> has no attribute 'update_timeline')*

------
https://chatgpt.com/codex/tasks/task_e_68dac4ca76ac8331bc05bd6b330a1299